### PR TITLE
Log error when latexmlmath fails to parse an equation

### DIFF
--- a/lib/metanorma/standoc/latexml_requirement.rb
+++ b/lib/metanorma/standoc/latexml_requirement.rb
@@ -11,31 +11,31 @@ module Metanorma
         version = version_output&.match(%r{\d+(.\d+)*})
 
         if version.to_s.empty?
-          @error_message = "LaTeXML not installed (or don't works properly)."\
-              " You must upgrade/install LaTeXML to #{@recommended_version} version"
+          @error_message = "LaTeXML is not available. (Or is PATH not setup properly?)"\
+            " You must upgrade/install LaTeXML to a version higher than `#{@recommended_version}`"
 
         elsif Gem::Version.new(version) < Gem::Version.new(@minimal_version)
-          @error_message = "Minimal supported LaTeXML version is #{@minimal_version} "\
-              "found #{version}, recommended version is #{@recommended_version}"
+          @error_message = "Minimal supported LaTeXML version is `#{@minimal_version}` "\
+              "Version `#{version}` found; recommended version is `#{@recommended_version}`"
 
         elsif Gem::Version.new(version) < Gem::Version.new(@recommended_version)
           version = "unknown" if version.to_s.empty?
-          header_msg = "latexmlmath version #{version} below #{@recommended_version}!"
+          header_msg = "latexmlmath version `#{version}` below `#{@recommended_version}`!"
           suggestion = if Gem.win_platform?
                          "cmd encoding is set to UTF-8 with `chcp 65001`"
                        else
                          "terminal encoding is set to UTF-8 with `export LANG=en_US.UTF-8`"
                        end
 
-          @error_message = "WARNING #{header_msg} Please sure that #{suggestion} command"
+          @error_message = "WARNING #{header_msg} Please sure that #{suggestion} command."
 
           @cmd = 'latexmlmath --strict --preload=amsmath -- -'
         else
           @cmd = 'latexmlmath --strict --preload=amsmath --inputencoding=UTF-8 -- -'
         end
       rescue
-        @error_message = "LaTeXML not installed (or don't works properly)."\
-            " You must upgrade/install LaTeXML to #{@recommended_version} version"
+        @error_message = "LaTeXML is not available. (Or is PATH not setup properly?)"\
+            " You must upgrade/install LaTeXML to a version higher than `#{@recommended_version}`"
       end
 
       def satisfied(abort = false)

--- a/lib/metanorma/standoc/latexml_requirement.rb
+++ b/lib/metanorma/standoc/latexml_requirement.rb
@@ -29,9 +29,9 @@ module Metanorma
 
           @error_message = "WARNING #{header_msg} Please sure that #{suggestion} command"
 
-          @cmd = "latexmlmath --strict --preload=amsmath -- -"
+          @cmd = 'latexmlmath --strict --preload=amsmath -- -'
         else
-          @cmd = "latexmlmath --strict --preload=amsmath --inputencoding=UTF-8 -- -"
+          @cmd = 'latexmlmath --strict --preload=amsmath --inputencoding=UTF-8 -- -'
         end
       rescue
         @error_message = "LaTeXML not installed (or don't works properly)."\

--- a/lib/metanorma/standoc/latexml_requirement.rb
+++ b/lib/metanorma/standoc/latexml_requirement.rb
@@ -29,9 +29,9 @@ module Metanorma
 
           @error_message = "WARNING #{header_msg} Please sure that #{suggestion} command"
 
-          @cmd = "latexmlmath --preload=amsmath -- -"
+          @cmd = "latexmlmath --strict --preload=amsmath -- -"
         else
-          @cmd = "latexmlmath --preload=amsmath --inputencoding=UTF-8 -- -"
+          @cmd = "latexmlmath --strict --preload=amsmath --inputencoding=UTF-8 -- -"
         end
       rescue
         @error_message = "LaTeXML not installed (or don't works properly)."\


### PR DESCRIPTION
Failures for latexmlmath are cryptic in locality -- no idea which exact equation failed.

e.g.
```
Fatal:unexpected:^ Script ^ can only appear in math mode
	at String; line 8 col 28 - line 8 col 28
	In Core::Definition::Primitive[Superscript] /Library/Perl/5.18/LaTeXML/Package/TeX.pool.ltxml; line 3790
	 <= Core::Stomach[@0x7f822b0c4da8]
1 fatal error
```

We want to at least display what failed, like this:

```
Fatal:unexpected:^ Script ^ can only appear in math mode
	at String; line 8 col 28 - line 8 col 28
	In Core::Definition::Primitive[Superscript] /Library/Perl/5.18/LaTeXML/Package/TeX.pool.ltxml; line 3790
	 <= Core::Stomach[@0x7f822b0c4da8]
1 fatal error
Math: ERROR: latexmlmath failed to process V = \frac{1}{2} \: {\bf u}^t \:
            \int_{surface} \: {B}^t \: D' \: B' \: ds
               \; {\bf u}}^t \: D \: B' \: ds
               \; {\bf u} \: B \: ds
               \; {\bf u} \: ds
               \; {\bf u}
```

This PR implements this error message and enforces `--strict` model in LaTeXML for detecting failure.
