### PR TITLE
Yaml2text: support for nested dot notation, the correct yaml file lookup

### DIFF
--- a/lib/asciidoctor/standoc/macros_yaml2text.rb
+++ b/lib/asciidoctor/standoc/macros_yaml2text.rb
@@ -20,47 +20,6 @@ module Asciidoctor
       end
     end
 
-    class YamlContext
-      attr_reader :context_object, :context_name, :parent_context
-
-      def initialize(context_object:,
-                    context_name:,
-                    parent_context: nil)
-        @context_object = context_object
-        @context_name = context_name
-        @parent_context = parent_context
-      end
-
-      def to_s
-        context_object.to_s
-      end
-
-      def respond_to?(name)
-        return true if context_name.to_s == name.to_s
-
-        parent_context.respond_to?(name)
-      end
-
-      def respond_to_missing?(name)
-        respond_to?(name)
-      end
-
-      def method_missing(name, *args)
-        # args = args.map do |argument|
-        #   argument.is_a?(YamlContext) ? argument.context_object : argument
-        # end
-        # if name == :values
-        #   return context_object.to_h.values
-        # end
-        if context_object.respond_to?(name) &&
-            (context_object.is_a?(OpenStruct) || context_object.is_a?(Array))
-          return block_given? ? context_object.send(name, *args, &block) : context_object.send(name, *args)
-        end
-
-        parent_context.send(name, *args)
-      end
-    end
-
     class YamlContextRenderer
       attr_reader :context_object, :context_name
 

--- a/spec/asciidoctor-standoc/macros_yaml2text_spec.rb
+++ b/spec/asciidoctor-standoc/macros_yaml2text_spec.rb
@@ -463,5 +463,102 @@ RSpec.describe Asciidoctor::Standoc::Yaml2TextPreprocessor do
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
+
+    context "Nested hash dot notation" do
+      let(:example_yaml_content) do
+        <<~TEXT
+          data:
+            acadsin-zho-hani-latn-2002:
+              code: acadsin-zho-hani-latn-2002
+              name:
+                en: Academica Sinica -- Chinese Tongyong Pinyin (2002)
+              authority: acadsin
+              lang:
+                system: iso-639-2
+                code: zho
+              source_script: Hani
+              target_script: Latn
+              system:
+                id: '2002'
+                specification: Academica Sinica -- Chinese Tongyong Pinyin (2002)
+              notes: 'NOTE: OGC 11-122r1 code `zho_Hani2Latn_AcadSin_2002`'
+        TEXT
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [yaml2text,#{example_file},authorities]
+          ----
+          [cols="a,a,a,a",options="header"]
+          |===
+          | Script conversion system authority code | Name in English | Notes | Name en
+
+          {authorities.data.*,key,EOI}
+          | {key} | {authorities.data[key]['code']} | {authorities.data[key]['notes']} | {authorities.data[key].name.en}
+          {EOI}
+
+          |===
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+            <sections>
+              <table id='_'>
+                <thead>
+                  <tr>
+                    <th align='left'>Script conversion system authority code</th>
+                    <th align='left'>Name in English</th>
+                    <th align='left'>Notes</th>
+                    <th align='left'>Name en</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td align='left'>
+                      <p id='_'>acadsin-zho-hani-latn-2002</p>
+                    </td>
+                    <td align='left'>
+                      <p id='_'>acadsin-zho-hani-latn-2002</p>
+                    </td>
+                    <td align='left'>
+                      <note id='_'>
+                        <p id='_'>
+                          OGC 11-122r1 code
+                          <tt>zho_Hani2Latn_AcadSin_2002</tt>
+                        </p>
+                      </note>
+                    </td>
+                    <td align='left'>
+                      <p id='_'>Academica Sinica — Chinese Tongyong Pinyin (2002)</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it 'correctly renders input yaml' do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
   end
 end


### PR DESCRIPTION
#260 , #261 , #262 

- support for any nesting level on variables
- lookup yaml file relative to the current adoc file(using `docfile` attribute)
- additional edge case specs

@ronaldtse @opoudjis i have added yaml file lookup using document `docfile` attribute and `Asciidoctor::PathResolver` object, review if its the correct approach.