### PR TITLE
Modify `yaml2text` to use Liquid syntax

### DIFF
--- a/lib/asciidoctor/standoc/views/datamodel/model_representation.adoc.erb
+++ b/lib/asciidoctor/standoc/views/datamodel/model_representation.adoc.erb
@@ -2,29 +2,29 @@
 [yaml2text,<%= model_path %>,definition]
 ----
 
-=== {definition.name || "<%= file_name %>"}
+=== {definition.name | default: "<%= file_name %>"}
 {definition.definition}
 
-{if definition.attributes}
-.{definition.name || "<%= file_name %>"} attributes
+{% if definition.attributes %}
+.{definition.name | default: "<%= file_name %>"} attributes
 |===
 |Name |Definition |Mandatory/ Optional/ Conditional |Max Occur |Data Type
 
-{definition.attributes&.*,key,EOK}
-|{key} |{definition.attributes[key].definition || "TODO: enum " + key.to_s + "'s definition"} |{definition.attributes[key]&.cardinality&.min == 0 ? "O" : "M"} |{definition.attributes[key]&.cardinality&.max == "*" ? "N" : "1"} |{definition.attributes[key].origin ? "<<" + definition.attributes[key].origin.to_s + ">>" : ""}`{definition.attributes[key].type}`
+{definition.attributes.*,key,EOK}
+|{key} |{% if definition.attributes[key].definition %}{{ definition.attributes[key].definition }}{% else %}TODO: enum {{ key }}'s definition{% endif %} |{% if definition.attributes[key].cardinality.min == 0 %}O{% else %}M{% endif %} |{% if definition.attributes[key].cardinality.max == "*" %}N{% else %}1{% endif %} |{% if definition.attributes[key].origin %}<<{{ definition.attributes[key].origin }}>>{% endif %} `{definition.attributes[key].type}`
 {EOK}
 |===
-{end}
+{% endif %}
 
-{if definition['values']}
-.{definition.name || "<%= file_name %>"} values
+{% if definition['values'] %}
+.{definition.name | default: "<%= file_name %>"} values
 |===
 |Name |Definition
 
-{definition['values']&.*,key,EOK}
+{definition['values'].*,key,EOK}
 |{key} |{definition['values'][key].definition}
 {EOK}
 |===
-{end}
+{% endif %}
 
 ----

--- a/lib/liquid/custom_blocks/key_iterator.rb
+++ b/lib/liquid/custom_blocks/key_iterator.rb
@@ -1,0 +1,21 @@
+module Liquid
+  module CustomBlocks
+    class KeyIterator < Block
+      def initialize(tag_name, markup, tokens)
+        super
+        @context_name, @var_name = markup.split(',').map(&:strip)
+      end
+
+      def render(context)
+        res = ''
+        iterator = context[@context_name].is_a?(Hash) ? context[@context_name].keys : context[@context_name]
+        iterator.each.with_index do |key, index|
+          context['index'] = index
+          context[@var_name] = key
+          res += super
+        end
+        res
+      end
+    end
+  end
+end

--- a/lib/liquid/custom_filters/values.rb
+++ b/lib/liquid/custom_filters/values.rb
@@ -1,0 +1,7 @@
+module Liquid
+  module CustomFilters
+    def values(list)
+      list.values
+    end
+  end
+end

--- a/spec/asciidoctor-standoc/macros_yaml2text_spec.rb
+++ b/spec/asciidoctor-standoc/macros_yaml2text_spec.rb
@@ -561,5 +561,62 @@ RSpec.describe Asciidoctor::Standoc::Yaml2TextPreprocessor do
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
+
+    context 'Liquid code snippets' do
+      let(:example_yaml_content) do
+        <<~TEXT
+          ---
+          - name: One
+            show: true
+          - name: Two
+            show: true
+          - name: Three
+            show: false
+        TEXT
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [yaml2text,#{example_file},my_context]
+          ----
+          {% for item in my_context %}
+          {% if item.show %}
+          {{ item.name | upcase }}
+          {{ item.name | size }}
+          {% endif %}
+          {% endfor %}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+            <p id='_'>ONE 3</p>
+            <p id='_'>TWO 3</p>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it 'renders liquid markup' do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
   end
 end


### PR DESCRIPTION
#322 changed macros yaml2text to use liquid as a render engine. Rewrite of Yaml2TextPreprocessor, hound issues. Now yaml2text supports liquid tags(see specs) and filters, example:

```yaml
# example.yml
---
- name: One
  show: true
- name: Two
  show: true
- name: Three
  show: false
```

```ruby
[yaml2text,example.yml,my_context]
----
{% for item in my_context %}
{% if item.show %}
{{ item.name | upcase }}
{{ item.name | size }}
{% endif %}
{% endfor %}
----
```

```xml
<sections>
  <p id='_'>ONE 3</p>
  <p id='_'>TWO 3</p>
</sections>
----
```