### PR TITLE
Implement json2text

### DIFF
--- a/lib/asciidoctor/standoc/base_structured_text_preprocessor.rb
+++ b/lib/asciidoctor/standoc/base_structured_text_preprocessor.rb
@@ -8,37 +8,20 @@ Liquid::Template.register_filter(Liquid::CustomFilters)
 
 module Asciidoctor
   module Standoc
-    class Yaml2TextPreprocessor < Asciidoctor::Extensions::Preprocessor
+    # Base class for processing structured data blocks(yaml, json)
+    class BaseStructuredTextPreprocessor < Asciidoctor::Extensions::Preprocessor
       BLOCK_START_REGEXP = /\{(.+?)\.\*,(.+),(.+)\}/
       BLOCK_END_REGEXP = /\A\{[A-Z]+\}\z/
 
-      attr_reader :document
-
-      # search document for block `yaml2text`
-      #   after that take template from block and read file into this template
-      #   example:
-      #     [yaml2text,foobar.yaml]
-      #     ----
-      #     === {item.name}
-      #     {item.desc}
-      #
-      #     {item.symbol}:: {item.symbol_def}
-      #     ----
-      #
-      #   with content of `foobar.yaml` file equal to:
-      #     - name: spaghetti
-      #       desc: wheat noodles of 9mm diameter
-      #       symbol: SPAG
-      #       symbol_def: the situation is message like spaghetti at a kid's
-      #
-      #   will produce:
-      #     === spaghetti
-      #     wheat noodles of 9mm diameter
-      #
-      #     SPAG:: the situation is message like spaghetti at a kid's meal
       def process(document, reader)
         input_lines = reader.readlines.to_enum
         Reader.new(processed_lines(document, input_lines))
+      end
+
+      protected
+
+      def content_from_file(document, file_path)
+        raise ArgumentError, "Implement `content_from_file` in your class"
       end
 
       private
@@ -46,45 +29,44 @@ module Asciidoctor
       def processed_lines(document, input_lines)
         result = []
         loop do
-          result.push(*process_yaml2text_blocks(document, input_lines))
+          result.push(*process_text_blocks(document, input_lines))
         end
         result
       end
 
-      def content_from_yaml(document, file_path)
+      def relative_file_path(document, file_path)
         docfile_directory = File.dirname(document.attributes["docfile"] || ".")
-        yaml_file_path = document
+        document
           .path_resolver
           .system_path(file_path, docfile_directory)
-        YAML.safe_load(File.read(yaml_file_path))
       end
 
-      def process_yaml2text_blocks(document, input_lines)
+      def process_text_blocks(document, input_lines)
         line = input_lines.next
-        yaml_block_match = line.match(/^\[yaml2text,(.+?),(.+?)\]/)
-        return [line] if yaml_block_match.nil?
+        block_match = line.match(/^\[#{config[:block_name]},(.+?),(.+?)\]/)
+        return [line] if block_match.nil?
 
         mark = input_lines.next
-        current_yaml_block = []
-        while (yaml_block_line = input_lines.next) != mark
-          current_yaml_block.push(yaml_block_line)
+        current_block = []
+        while (block_line = input_lines.next) != mark
+          current_block.push(block_line)
         end
-        read_yaml_and_parse_template(document,
-                                     current_yaml_block,
-                                     yaml_block_match)
+        read_content_and_parse_template(document,
+                                     current_block,
+                                     block_match)
       end
 
-      def read_yaml_and_parse_template(document, current_block, block_match)
+      def read_content_and_parse_template(document, current_block, block_match)
         transformed_liquid_lines = current_block
           .map(&method(:transform_line_liquid))
-        context_items = content_from_yaml(document, block_match[1])
+        context_items = content_from_file(document, block_match[1])
         parse_context_block(document: document,
                             context_lines: transformed_liquid_lines,
                             context_items: context_items,
                             context_name: block_match[2])
       rescue StandardError => exception
         document.logger
-          .warn("Failed to parse yaml2text block: #{exception.message}")
+          .warn("Failed to parse #{config[:block_name]} block: #{exception.message}")
         []
       end
 
@@ -100,6 +82,8 @@ module Asciidoctor
         line
           .gsub(/(?<!{){(?!%)([^{}]+)(?<!%)}(?!})/, '{{\1}}')
           .gsub(/[a-z\.]+\#/, "index")
+          .gsub(/{{(.+)\s+\+\s+(\d+)\s*?}}/, '{{ \1 | plus: \2 }}')
+          .gsub(/{{(.+)\s+\-\s+(\d+)\s*?}}/, '{{ \1 | minus: \2 }}')
           .gsub(/{{(.+).values(.*?)}}/,
                 '{% assign custom_value = \1 | values %}{{custom_value\2}}')
       end

--- a/lib/asciidoctor/standoc/base_structured_text_preprocessor.rb
+++ b/lib/asciidoctor/standoc/base_structured_text_preprocessor.rb
@@ -20,7 +20,7 @@ module Asciidoctor
 
       protected
 
-      def content_from_file(document, file_path)
+      def content_from_file(_document, _file_path)
         raise ArgumentError, "Implement `content_from_file` in your class"
       end
 
@@ -52,8 +52,8 @@ module Asciidoctor
           current_block.push(block_line)
         end
         read_content_and_parse_template(document,
-                                     current_block,
-                                     block_match)
+                                        current_block,
+                                        block_match)
       end
 
       def read_content_and_parse_template(document, current_block, block_match)
@@ -66,7 +66,8 @@ module Asciidoctor
                             context_name: block_match[2])
       rescue StandardError => exception
         document.logger
-          .warn("Failed to parse #{config[:block_name]} block: #{exception.message}")
+          .warn("Failed to parse #{config[:block_name]} \
+            block: #{exception.message}")
         []
       end
 

--- a/lib/asciidoctor/standoc/converter.rb
+++ b/lib/asciidoctor/standoc/converter.rb
@@ -24,6 +24,7 @@ module Asciidoctor
         preprocessor Asciidoctor::Standoc::Datamodel::AttributesTablePreprocessor
         preprocessor Asciidoctor::Standoc::Datamodel::DiagramPreprocessor
         preprocessor Asciidoctor::Standoc::Yaml2TextPreprocessor
+        preprocessor Asciidoctor::Standoc::Json2TextPreprocessor
         inline_macro Asciidoctor::Standoc::AltTermInlineMacro
         inline_macro Asciidoctor::Standoc::DeprecatedTermInlineMacro
         inline_macro Asciidoctor::Standoc::DomainTermInlineMacro
@@ -65,7 +66,7 @@ module Asciidoctor
         attr_accessor :_file
       end
 
-      def self.inherited( k )
+      def self.inherited(k)
         k._file = caller_locations.first.absolute_path
       end
 

--- a/lib/asciidoctor/standoc/json2_text_preprocessor.rb
+++ b/lib/asciidoctor/standoc/json2_text_preprocessor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "asciidoctor/standoc/base_structured_text_preprocessor"
+
+module Asciidoctor
+  module Standoc
+    class Json2TextPreprocessor < BaseStructuredTextPreprocessor
+      # search document for block `yaml2text`
+      #   after that take template from block and read file into this template
+      #   example:
+      #     [yaml2text,foobar.yaml]
+      #     ----
+      #     === {item.name}
+      #     {item.desc}
+      #
+      #     {item.symbol}:: {item.symbol_def}
+      #     ----
+      #
+      #   with content of `foobar.yaml` file equal to:
+      #     - name: spaghetti
+      #       desc: wheat noodles of 9mm diameter
+      #       symbol: SPAG
+      #       symbol_def: the situation is message like spaghetti at a kid's
+      #
+      #   will produce:
+      #     === spaghetti
+      #     wheat noodles of 9mm diameter
+      #
+      #     SPAG:: the situation is message like spaghetti at a kid's meal
+
+      def initialize(config = {})
+        super
+        @config[:block_name] = "json2text"
+      end
+
+      protected
+
+      def content_from_file(document, file_path)
+        JSON.parse(File.read(relative_file_path(document, file_path)))
+      end
+    end
+  end
+end

--- a/lib/asciidoctor/standoc/yaml2_text_preprocessor.rb
+++ b/lib/asciidoctor/standoc/yaml2_text_preprocessor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "asciidoctor/standoc/base_structured_text_preprocessor"
+
+module Asciidoctor
+  module Standoc
+    class Yaml2TextPreprocessor < BaseStructuredTextPreprocessor
+      # search document for block `yaml2text`
+      #   after that take template from block and read file into this template
+      #   example:
+      #     [yaml2text,foobar.yaml]
+      #     ----
+      #     === {item.name}
+      #     {item.desc}
+      #
+      #     {item.symbol}:: {item.symbol_def}
+      #     ----
+      #
+      #   with content of `foobar.yaml` file equal to:
+      #     - name: spaghetti
+      #       desc: wheat noodles of 9mm diameter
+      #       symbol: SPAG
+      #       symbol_def: the situation is message like spaghetti at a kid's
+      #
+      #   will produce:
+      #     === spaghetti
+      #     wheat noodles of 9mm diameter
+      #
+      #     SPAG:: the situation is message like spaghetti at a kid's meal
+
+      def initialize(config = {})
+        super
+        @config[:block_name] = "yaml2text"
+      end
+
+      protected
+
+      def content_from_file(document, file_path)
+        YAML.safe_load(File.read(relative_file_path(document, file_path)))
+      end
+    end
+  end
+end

--- a/spec/asciidoctor-standoc/macros_json2text_spec.rb
+++ b/spec/asciidoctor-standoc/macros_json2text_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-RSpec.describe Asciidoctor::Standoc::Yaml2TextPreprocessor do
+RSpec.describe Asciidoctor::Standoc::Json2TextPreprocessor do
   it_behaves_like "structured data 2 text preprocessor" do
-    let(:extention) { "yaml" }
+    let(:extention) { "json" }
     def transform_to_type(data)
-      data.to_yaml
+      data.to_json
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,9 @@ require "equivalent-xml"
 require "metanorma"
 require "metanorma/standoc"
 require "rexml/document"
-require 'byebug'
+require "byebug"
+
+Dir[File.expand_path("./support/**/**/*.rb", __dir__)].each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -44,150 +46,150 @@ def xmlpp(x)
   s = ""
   f = REXML::Formatters::Pretty.new(2)
   f.compact = true
-  f.write(REXML::Document.new(x),s)
+  f.write(REXML::Document.new(x), s)
   s
 end
 
-ASCIIDOC_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :no-isobib:
+ASCIIDOC_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :no-isobib:
 
 HDR
 
-DUMBQUOTE_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :no-isobib:
-      :smartquotes: false
+DUMBQUOTE_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :no-isobib:
+  :smartquotes: false
 
 HDR
 
-ISOBIB_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :no-isobib-cache:
+ISOBIB_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :no-isobib-cache:
 
 HDR
 
-FLUSH_CACHE_ISOBIB_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :flush-caches:
+FLUSH_CACHE_ISOBIB_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :flush-caches:
 
 HDR
 
-CACHED_ISOBIB_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
+CACHED_ISOBIB_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
 
 HDR
 
-LOCAL_CACHED_ISOBIB_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :local-cache:
+LOCAL_CACHED_ISOBIB_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :local-cache:
 
 HDR
 
-LOCAL_ONLY_CACHED_ISOBIB_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :novalid:
-      :local-cache-only:
+LOCAL_ONLY_CACHED_ISOBIB_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :novalid:
+  :local-cache-only:
 
 HDR
 
-VALIDATING_BLANK_HDR = <<~"HDR"
-      = Document title
-      Author
-      :docfile: test.adoc
-      :nodoc:
-      :no-isobib:
+VALIDATING_BLANK_HDR = <<~"HDR".freeze
+  = Document title
+  Author
+  :docfile: test.adoc
+  :nodoc:
+  :no-isobib:
 
 HDR
 
-NORM_REF_BOILERPLATE = <<~"HDR"
-<p id="_">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
+NORM_REF_BOILERPLATE = <<~"HDR".freeze
+  <p id="_">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
 HDR
 
-BLANK_HDR = <<~"HDR"
-<?xml version="1.0" encoding="UTF-8"?>
-<standard-document xmlns="https://www.metanorma.org/ns/standoc">
-<bibdata type="standard">
-<title language="en" format="text/plain">Document title</title>
-  <language>en</language>
-  <script>Latn</script>
-  <status><stage>published</stage></status>
-  <copyright>
-    <from>#{Time.new.year}</from>
-  </copyright>
-  <ext>
-  <doctype>article</doctype>
-  </ext>
-</bibdata>
+BLANK_HDR = <<~"HDR".freeze
+  <?xml version="1.0" encoding="UTF-8"?>
+  <standard-document xmlns="https://www.metanorma.org/ns/standoc">
+  <bibdata type="standard">
+  <title language="en" format="text/plain">Document title</title>
+    <language>en</language>
+    <script>Latn</script>
+    <status><stage>published</stage></status>
+    <copyright>
+      <from>#{Time.new.year}</from>
+    </copyright>
+    <ext>
+    <doctype>article</doctype>
+    </ext>
+  </bibdata>
 HDR
 
-HTML_HDR = <<~END
-        <html xmlns:epub="http://www.idpf.org/2007/ops">
-          <head>
-            <title>test</title>
-          </head>
-          <body lang="EN-US" link="blue" vlink="#954F72">
-            <div class="title-section">
-              <p>&#160;</p>
-            </div>
-            <br/>
-            <div class="prefatory-section">
-              <p>&#160;</p>
-            </div>
-            <br/>
-            <div class="main-section">
+HTML_HDR = <<~END.freeze
+  <html xmlns:epub="http://www.idpf.org/2007/ops">
+    <head>
+      <title>test</title>
+    </head>
+    <body lang="EN-US" link="blue" vlink="#954F72">
+      <div class="title-section">
+        <p>&#160;</p>
+      </div>
+      <br/>
+      <div class="prefatory-section">
+        <p>&#160;</p>
+      </div>
+      <br/>
+      <div class="main-section">
 END
 
-WORD_HDR = <<~END
-       <html xmlns:epub="http://www.idpf.org/2007/ops">
-         <head>
-           <title>test</title>
-         </head>
-         <body lang="EN-US" link="blue" vlink="#954F72">
-           <div class="WordSection1">
-             <p>&#160;</p>
-           </div>
-           <br clear="all" class="section"/>
-           <div class="WordSection2">
-             <p>&#160;</p>
-           </div>
-           <br clear="all" class="section"/>
-           <div class="WordSection3">
+WORD_HDR = <<~END.freeze
+  <html xmlns:epub="http://www.idpf.org/2007/ops">
+    <head>
+      <title>test</title>
+    </head>
+    <body lang="EN-US" link="blue" vlink="#954F72">
+      <div class="WordSection1">
+        <p>&#160;</p>
+      </div>
+      <br clear="all" class="section"/>
+      <div class="WordSection2">
+        <p>&#160;</p>
+      </div>
+      <br clear="all" class="section"/>
+      <div class="WordSection3">
 END
 
 def examples_path(path)
-  File.join(File.expand_path('./examples', __dir__), path)
+  File.join(File.expand_path("./examples", __dir__), path)
 end
 
 def fixtures_path(path)
-  File.join(File.expand_path('./fixtures', __dir__), path)
+  File.join(File.expand_path("./fixtures", __dir__), path)
 end
 
 def stub_fetch_ref(**opts)
@@ -212,8 +214,8 @@ def stub_fetch_ref(**opts)
   hit_pages = double("hit_pages")
   expect(hit_pages).to receive(:first).and_return(hit_page).at_least :once
 
-  expect(Isobib::IsoBibliography).to receive(:search).
-    and_wrap_original do |search, *args|
+  expect(Isobib::IsoBibliography).to receive(:search)
+    .and_wrap_original do |search, *args|
     code = args[0]
     expect(code).to be_instance_of String
     xml = get_xml(search, code, opts)
@@ -246,4 +248,3 @@ def mock_open_uri(code)
     File.read file, encoding: "utf-8"
   end.at_least :once
 end
-

--- a/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
+++ b/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
@@ -1,0 +1,579 @@
+RSpec.shared_examples 'structured data 2 text preprocessor' do
+  describe '#process' do
+    let(:example_file) { "example.#{extention}" }
+
+    before do
+      File.open(example_file, 'w') do |n|
+        n.puts(transform_to_type(example_content))
+      end
+    end
+
+    after do
+      FileUtils.rm_rf(example_file)
+    end
+
+    context 'Array of hashes' do
+      let(:example_content) do
+        [{"name"=>"spaghetti",
+        "desc"=>"wheat noodles of 9mm diameter",
+        "symbol"=>"SPAG",
+        "symbol_def"=>"the situation is message like spaghetti at a kid's meal"}]
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},my_context]
+          ----
+          {my_context.*,item,EOF}
+            {item.name}:: {item.desc}
+          {EOF}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <dl id='_'>
+            <dt>spaghetti</dt>
+            <dd>
+              <p id='_'>wheat noodles of 9mm diameter</p>
+            </dd>
+          </dl>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'An array of strings' do
+      let(:example_content) do
+        ["lorem", "ipsum", "dolor"]
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},ar]
+          ----
+          {ar.*,s,EOS}
+          === {s.#} {s}
+
+          This section is about {s}.
+
+          {EOS}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+             <title>0 lorem</title>
+             <p id='_'>This section is about lorem.</p>
+           </clause>
+           <clause id='_' inline-header='false' obligation='normative'>
+             <title>1 ipsum</title>
+             <p id='_'>This section is about ipsum.</p>
+           </clause>
+           <clause id='_' inline-header='false' obligation='normative'>
+             <title>2 dolor</title>
+             <p id='_'>This section is about dolor.</p>
+            </clause>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'A simple hash' do
+      let(:example_content) do
+        {"name"=>"Lorem ipsum", "desc"=>"dolor sit amet"}
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},my_item]
+          ----
+          === {my_item.name}
+
+          {my_item.desc}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+            <title>Lorem ipsum</title>
+            <p id='_'>dolor sit amet</p>
+          </clause>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'A simple hash with free keys' do
+      let(:example_content) do
+        {"name"=>"Lorem ipsum", "desc"=>"dolor sit amet"}
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},my_item]
+          ----
+          {my_item.*,key,EOI}
+          === {key}
+
+          {my_item[key]}
+
+          {EOI}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+              <title>name</title>
+              <p id='_'>Lorem ipsum</p>
+            </clause>
+            <clause id='_' inline-header='false' obligation='normative'>
+              <title>desc</title>
+              <p id='_'>dolor sit amet</p>
+          </clause>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'An array of hashes' do
+      let(:example_content) do
+        [{"name"=>"Lorem", "desc"=>"ipsum", "nums"=>[2]},
+        {"name"=>"dolor", "desc"=>"sit", "nums"=>[]},
+        {"name"=>"amet", "desc"=>"lorem", "nums"=>[2, 4, 6]}]
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},ar]
+          ----
+          {ar.*,item,EOF}
+
+          {item.name}:: {item.desc}
+
+          {item.nums.*,num,EON}
+          - {item.name}: {num}
+          {EON}
+
+          {EOF}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+            #{BLANK_HDR}
+            <sections>
+            <dl id='_'>
+            <dt>Lorem</dt>
+            <dd>
+              <p id='_'>ipsum</p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>Lorem: 2</p>
+                </li>
+              </ul>
+            </dd>
+            <dt>dolor</dt>
+            <dd>
+              <p id='_'>sit</p>
+            </dd>
+            <dt>amet</dt>
+            <dd>
+              <p id='_'>lorem</p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>amet: 2</p>
+                </li>
+                <li>
+                  <p id='_'>amet: 4</p>
+                </li>
+                <li>
+                  <p id='_'>amet: 6</p>
+                </li>
+              </ul>
+            </dd>
+          </dl>
+            </sections>
+            </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context "An array with interpolated file names, etc. \
+              for Asciidoc's consumption" do
+      let(:example_content) do
+        {"prefix"=>"doc-", "items"=>["lorem", "ipsum", "dolor"]}
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},#{extention}]
+          ------
+          First item is {#{extention}.items[0]}.
+          Last item is {#{extention}.items[-1]}.
+
+          {#{extention}.items.*,s,EOS}
+          === {s.#} -> {s.# + 1} {s} == {#{extention}.items[s.#]}
+
+          [source,ruby]
+          ----
+          include::{#{extention}.prefix}{s.#}.rb[]
+          ----
+
+          {EOS}
+          ------
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+            <preface>
+              <foreword id='_' obligation='informative'>
+                <title>Foreword</title>
+                <p id='_'>First item is lorem. Last item is dolor.</p>
+              </foreword>
+            </preface>
+            <sections>
+              <clause id='_' inline-header='false' obligation='normative'>
+                <title>0 → 1 lorem == lorem</title>
+                <sourcecode lang='ruby' id='_'>link:doc-0.rb[]</sourcecode>
+              </clause>
+              <clause id='_' inline-header='false' obligation='normative'>
+                <title>1 → 2 ipsum == ipsum</title>
+                <sourcecode lang='ruby' id='_'>link:doc-1.rb[]</sourcecode>
+              </clause>
+              <clause id='_' inline-header='false' obligation='normative'>
+                <title>2 → 3 dolor == dolor</title>
+                <sourcecode lang='ruby' id='_'>link:doc-2.rb[]</sourcecode>
+              </clause>
+            </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context "Array of language codes" do
+      let(:example_content) do
+        YAML.load(File.read(File.expand_path('../../assets/codes.yml', __dir__)))
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},ar]
+          ----
+          {ar.*,item,EOF}
+          .{item.values[1]}
+          [%noheader,cols="h,1"]
+          |===
+          {item.*,key,EOK}
+          | {key} | {item[key]}
+
+          {EOK}
+          |===
+          {EOF}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+            <sections>
+              #{File.read(File.expand_path('../../examples/codes_table.html', __dir__))}
+            </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context "Nested hash dot notation" do
+      let(:example_content) do
+        {"data"=>
+          {"acadsin-zho-hani-latn-2002"=>
+            {"code"=>"acadsin-zho-hani-latn-2002",
+            "name"=>{"en"=>"Academica Sinica -- Chinese Tongyong Pinyin (2002)"},
+            "authority"=>"acadsin",
+            "lang"=>{"system"=>"iso-639-2", "code"=>"zho"},
+            "source_script"=>"Hani",
+            "target_script"=>"Latn",
+            "system"=>
+              {"id"=>"2002",
+              "specification"=>"Academica Sinica -- Chinese Tongyong Pinyin (2002)"},
+            "notes"=>"NOTE: OGC 11-122r1 code `zho_Hani2Latn_AcadSin_2002`"}}}
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},authorities]
+          ----
+          [cols="a,a,a,a",options="header"]
+          |===
+          | Script conversion system authority code | Name in English | Notes | Name en
+
+          {authorities.data.*,key,EOI}
+          | {key} | {authorities.data[key]['code']} | {authorities.data[key]['notes']} | {authorities.data[key].name.en}
+          {EOI}
+
+          |===
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+            <sections>
+              <table id='_'>
+                <thead>
+                  <tr>
+                    <th valign="top" align='left'>Script conversion system authority code</th>
+                    <th valign="top" align='left'>Name in English</th>
+                    <th valign="top" align='left'>Notes</th>
+                    <th valign="top" align='left'>Name en</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td valign="top" align='left'>
+                      <p id='_'>acadsin-zho-hani-latn-2002</p>
+                    </td>
+                    <td valign="top" align='left'>
+                      <p id='_'>acadsin-zho-hani-latn-2002</p>
+                    </td>
+                    <td valign="top" align='left'>
+                      <note id='_'>
+                        <p id='_'>
+                          OGC 11-122r1 code
+                          <tt>zho_Hani2Latn_AcadSin_2002</tt>
+                        </p>
+                      </note>
+                    </td>
+                    <td valign="top" align='left'>
+                      <p id='_'>Academica Sinica — Chinese Tongyong Pinyin (2002)</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'Liquid code snippets' do
+      let(:example_content) do
+        [{"name"=>"One", "show"=>true},
+        {"name"=>"Two", "show"=>true},
+        {"name"=>"Three", "show"=>false}]
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},my_context]
+          ----
+          {% for item in my_context %}
+          {% if item.show %}
+          {{ item.name | upcase }}
+          {{ item.name | size }}
+          {% endif %}
+          {% endfor %}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+            <p id='_'>ONE 3</p>
+            <p id='_'>TWO 3</p>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it 'renders liquid markup' do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true),
+            ),
+          ),
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
+++ b/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
@@ -1,9 +1,9 @@
-RSpec.shared_examples 'structured data 2 text preprocessor' do
-  describe '#process' do
+RSpec.shared_examples "structured data 2 text preprocessor" do
+  describe "#process" do
     let(:example_file) { "example.#{extention}" }
 
     before do
-      File.open(example_file, 'w') do |n|
+      File.open(example_file, "w") do |n|
         n.puts(transform_to_type(example_content))
       end
     end
@@ -12,12 +12,12 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
       FileUtils.rm_rf(example_file)
     end
 
-    context 'Array of hashes' do
+    context "Array of hashes" do
       let(:example_content) do
-        [{"name"=>"spaghetti",
-        "desc"=>"wheat noodles of 9mm diameter",
-        "symbol"=>"SPAG",
-        "symbol_def"=>"the situation is message like spaghetti at a kid's meal"}]
+        [{ "name" => "spaghetti",
+           "desc" => "wheat noodles of 9mm diameter",
+           "symbol" => "SPAG",
+           "symbol_def" => "the situation is message like spaghetti at a kid's meal" }]
       end
       let(:input) do
         <<~TEXT
@@ -58,14 +58,14 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
-    context 'An array of strings' do
+    context "An array of strings" do
       let(:example_content) do
         ["lorem", "ipsum", "dolor"]
       end
@@ -117,16 +117,16 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
-    context 'A simple hash' do
+    context "A simple hash" do
       let(:example_content) do
-        {"name"=>"Lorem ipsum", "desc"=>"dolor sit amet"}
+        { "name" => "Lorem ipsum", "desc" => "dolor sit amet" }
       end
       let(:input) do
         <<~TEXT
@@ -165,16 +165,16 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
-    context 'A simple hash with free keys' do
+    context "A simple hash with free keys" do
       let(:example_content) do
-        {"name"=>"Lorem ipsum", "desc"=>"dolor sit amet"}
+        { "name" => "Lorem ipsum", "desc" => "dolor sit amet" }
       end
       let(:input) do
         <<~TEXT
@@ -220,18 +220,18 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
-    context 'An array of hashes' do
+    context "An array of hashes" do
       let(:example_content) do
-        [{"name"=>"Lorem", "desc"=>"ipsum", "nums"=>[2]},
-        {"name"=>"dolor", "desc"=>"sit", "nums"=>[]},
-        {"name"=>"amet", "desc"=>"lorem", "nums"=>[2, 4, 6]}]
+        [{ "name" => "Lorem", "desc" => "ipsum", "nums" => [2] },
+         { "name" => "dolor", "desc" => "sit", "nums" => [] },
+         { "name" => "amet", "desc" => "lorem", "nums" => [2, 4, 6] }]
       end
       let(:input) do
         <<~TEXT
@@ -302,9 +302,9 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
@@ -312,7 +312,7 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
     context "An array with interpolated file names, etc. \
               for Asciidoc's consumption" do
       let(:example_content) do
-        {"prefix"=>"doc-", "items"=>["lorem", "ipsum", "dolor"]}
+        { "prefix" => "doc-", "items" => ["lorem", "ipsum", "dolor"] }
       end
       let(:input) do
         <<~TEXT
@@ -374,16 +374,18 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
     context "Array of language codes" do
       let(:example_content) do
-        YAML.load(File.read(File.expand_path('../../assets/codes.yml', __dir__)))
+        YAML.safe_load(
+          File.read(File.expand_path("../../assets/codes.yml", __dir__))
+        )
       end
       let(:input) do
         <<~TEXT
@@ -426,27 +428,29 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
     context "Nested hash dot notation" do
       let(:example_content) do
-        {"data"=>
-          {"acadsin-zho-hani-latn-2002"=>
-            {"code"=>"acadsin-zho-hani-latn-2002",
-            "name"=>{"en"=>"Academica Sinica -- Chinese Tongyong Pinyin (2002)"},
-            "authority"=>"acadsin",
-            "lang"=>{"system"=>"iso-639-2", "code"=>"zho"},
-            "source_script"=>"Hani",
-            "target_script"=>"Latn",
-            "system"=>
-              {"id"=>"2002",
-              "specification"=>"Academica Sinica -- Chinese Tongyong Pinyin (2002)"},
-            "notes"=>"NOTE: OGC 11-122r1 code `zho_Hani2Latn_AcadSin_2002`"}}}
+        { "data" =>
+          { "acadsin-zho-hani-latn-2002" =>
+            { "code" => "acadsin-zho-hani-latn-2002",
+              "name" => {
+                "en" => "Academica Sinica -- Chinese Tongyong Pinyin (2002)",
+              },
+              "authority" => "acadsin",
+              "lang" => { "system" => "iso-639-2", "code" => "zho" },
+              "source_script" => "Hani",
+              "target_script" => "Latn",
+              "system" =>
+              { "id" => "2002",
+                "specification" => "Academica Sinica -- Chinese Tongyong Pinyin (2002)" },
+              "notes" => "NOTE: OGC 11-122r1 code `zho_Hani2Latn_AcadSin_2002`" } } }
       end
       let(:input) do
         <<~TEXT
@@ -518,18 +522,18 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
 
-    context 'Liquid code snippets' do
+    context "Liquid code snippets" do
       let(:example_content) do
-        [{"name"=>"One", "show"=>true},
-        {"name"=>"Two", "show"=>true},
-        {"name"=>"Three", "show"=>false}]
+        [{ "name" => "One", "show" => true },
+         { "name" => "Two", "show" => true },
+         { "name" => "Three", "show" => false }]
       end
       let(:input) do
         <<~TEXT
@@ -563,15 +567,15 @@ RSpec.shared_examples 'structured data 2 text preprocessor' do
         TEXT
       end
 
-      it 'renders liquid markup' do
+      it "renders liquid markup" do
         expect(
           xmlpp(
             strip_guid(
               Asciidoctor.convert(input,
                                   backend: :standoc,
-                                  header_footer: true),
-            ),
-          ),
+                                  header_footer: true)
+            )
+          )
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end


### PR DESCRIPTION
metanorma/metanorma-standoc#321 support for json2text macros, refactored yaml2text to use `BaseStructuredTextPreprocessor`  inheritance, added shared_examples folder, moved specs for yaml2text into the shared examples