### PR TITLE
Date format support in yaml2text template

### DIFF
--- a/lib/asciidoctor/standoc/yaml2_text_preprocessor.rb
+++ b/lib/asciidoctor/standoc/yaml2_text_preprocessor.rb
@@ -36,7 +36,9 @@ module Asciidoctor
       protected
 
       def content_from_file(document, file_path)
-        YAML.safe_load(File.read(relative_file_path(document, file_path)))
+        YAML.safe_load(
+          File.read(relative_file_path(document, file_path)),
+          [Date, Time])
       end
     end
   end

--- a/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
+++ b/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
@@ -579,5 +579,51 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
         ).to(be_equivalent_to(xmlpp(output)))
       end
     end
+
+    context "Date time objects support" do
+      let(:example_content) do
+        { "date" => Date.parse('1889-09-28'), "time" => Time.gm(2020, 10, 15, 5, 34) }
+      end
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [#{extention}2text,#{example_file},my_context]
+          ----
+          {{my_context.time}}
+
+          {{my_context.date}}
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+            <p id='_'>1889-09-28</p>
+            <p id='_'>2020-10-15 05:34:00 UTC</p>
+          </sections>
+          </standard-document>
+        TEXT
+      end
+
+      it "renders liquid markup" do
+        expect(
+          xmlpp(
+            strip_guid(
+              Asciidoctor.convert(input,
+                                  backend: :standoc,
+                                  header_footer: true)
+            )
+          )
+        ).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
   end
 end


### PR DESCRIPTION
metanorma/metanorma-standoc#344 added support for `Date` and `Time` objects in loaded yaml, added specs. 