### PR TITLE
Support for `lutaml_diagram` and `lutaml_datamodel_attributes_table` macroses, metanorma-plugin-lutaml

### DIFF
--- a/lib/asciidoctor/standoc/converter.rb
+++ b/lib/asciidoctor/standoc/converter.rb
@@ -26,6 +26,7 @@ module Asciidoctor
         preprocessor Metanorma::Plugin::Datastruct::Json2TextPreprocessor
         preprocessor Metanorma::Plugin::Datastruct::Yaml2TextPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
+        preprocessor Metanorma::Plugin::Lutaml::LutamlDatamodelAttributesTablePreprocessor
         inline_macro Asciidoctor::Standoc::AltTermInlineMacro
         inline_macro Asciidoctor::Standoc::DeprecatedTermInlineMacro
         inline_macro Asciidoctor::Standoc::DomainTermInlineMacro
@@ -37,6 +38,7 @@ module Asciidoctor
         block Asciidoctor::Standoc::ToDoAdmonitionBlock
         treeprocessor Asciidoctor::Standoc::ToDoInlineAdmonitionBlock
         block Asciidoctor::Standoc::PlantUMLBlockMacro
+        block Metanorma::Plugin::Lutaml::LutamlDiagramBlock
         block Asciidoctor::Standoc::PseudocodeBlockMacro
       end
 

--- a/lib/asciidoctor/standoc/converter.rb
+++ b/lib/asciidoctor/standoc/converter.rb
@@ -26,7 +26,7 @@ module Asciidoctor
         preprocessor Metanorma::Plugin::Datastruct::Json2TextPreprocessor
         preprocessor Metanorma::Plugin::Datastruct::Yaml2TextPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
-        preprocessor Metanorma::Plugin::Lutaml::LutamlDatamodelAttributesTablePreprocessor
+        preprocessor Metanorma::Plugin::Lutaml::LutamlUmlAttributesTablePreprocessor
         inline_macro Asciidoctor::Standoc::AltTermInlineMacro
         inline_macro Asciidoctor::Standoc::DeprecatedTermInlineMacro
         inline_macro Asciidoctor::Standoc::DomainTermInlineMacro

--- a/metanorma-standoc.gemspec
+++ b/metanorma-standoc.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "isodoc", "~> 1.2.0"
   spec.add_dependency "iev", "~> 0.2.1"
   spec.add_dependency "metanorma-plugin-datastruct"
-  spec.add_dependency "metanorma-plugin-lutaml"
+  spec.add_dependency "metanorma-plugin-lutaml", "~> 0.2.0"
   # relaton-cli not just relaton, to avoid circular reference in metanorma
   spec.add_dependency "relaton-cli", "~> 1.6.0"
   spec.add_dependency "relaton-iev", "~> 1.1.0"

--- a/metanorma-standoc.gemspec
+++ b/metanorma-standoc.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "isodoc", "~> 1.2.0"
   spec.add_dependency "iev", "~> 0.2.1"
   spec.add_dependency "metanorma-plugin-datastruct"
-  spec.add_dependency "metanorma-plugin-lutaml", "~> 0.2.0"
+  spec.add_dependency "metanorma-plugin-lutaml", "~> 0.2.1"
   # relaton-cli not just relaton, to avoid circular reference in metanorma
   spec.add_dependency "relaton-cli", "~> 1.6.0"
   spec.add_dependency "relaton-iev", "~> 1.1.0"

--- a/spec/asciidoctor-standoc/macros_lutaml_spec.rb
+++ b/spec/asciidoctor-standoc/macros_lutaml_spec.rb
@@ -44,27 +44,27 @@ RSpec.describe 'Lutaml macros' do
         <clause id="_" inline-header="false" obligation="normative">
         <title>a3m_data_quality_criterion</title>
         <p id="_">supertypes →
-        explicit → assessment_specification</p>
+        explicit → </p>
         </clause>
         <clause id="_" inline-header="false" obligation="normative">
         <title>a3m_data_quality_criterion_specific_applied_value</title>
         <p id="_">supertypes →
-        explicit → criterion_to_assign_the_value</p>
+        explicit → </p>
         </clause>
         <clause id="_" inline-header="false" obligation="normative">
         <title>a3m_data_quality_target_accuracy_association</title>
         <p id="_">supertypes →
-        explicit → id</p>
+        explicit → </p>
         </clause>
         <clause id="_" inline-header="false" obligation="normative">
         <title>a3m_detailed_report_request</title>
         <p id="_">supertypes →
-        explicit → value_type_requested</p>
+        explicit → </p>
         </clause>
         <clause id="_" inline-header="false" obligation="normative">
         <title>a3m_summary_report_request_with_representative_value</title>
         <p id="_">supertypes →
-        explicit → value_type_requested</p>
+        explicit → </p>
         </clause></clause>
         </sections>
         </standard-document>

--- a/spec/asciidoctor-standoc/macros_spec.rb
+++ b/spec/asciidoctor-standoc/macros_spec.rb
@@ -519,7 +519,7 @@ OUTPUT
     end
   end
 
-  context 'when lutaml_datamodel_attributes_table' do
+  context 'when lutaml_uml_attributes_table' do
     let(:example_file) { fixtures_path("diagram_definitions.lutaml") }
     let(:input) do
       <<~"OUTPUT"
@@ -531,7 +531,7 @@ OUTPUT
         :no-isobib:
         :imagesdir: spec/assets
 
-        [lutaml_datamodel_attributes_table,#{example_file},AttributeProfile]
+        [lutaml_uml_attributes_table,#{example_file},AttributeProfile]
       OUTPUT
     end
     let(:output) do

--- a/spec/asciidoctor-standoc/macros_spec.rb
+++ b/spec/asciidoctor-standoc/macros_spec.rb
@@ -477,6 +477,115 @@ OUTPUT
 OUTPUT
     end
 
+  context 'when lutaml_diagram' do
+    let(:input) do
+      <<~"OUTPUT"
+        = Document title
+        Author
+        :docfile: test.adoc
+        :nodoc:
+        :novalid:
+        :no-isobib:
+        :imagesdir: spec/assets
+
+        [lutaml_diagram]
+        ....
+        diagram MyView {
+          fontname "Arial"
+          title "my diagram"
+          class Foo {}
+        }
+        ....
+      OUTPUT
+    end
+    let(:output) do
+      <<~"OUTPUT"
+      #{BLANK_HDR}
+        <sections>
+        <figure id="_">
+        <image src="spec/assets/_.png" id="_" mimetype="image/png" height="auto" width="auto"/>
+        </figure>
+        </sections>
+        </standard-document>
+      OUTPUT
+    end
+
+    it "processes the lutaml_diagram" do
+      expect(
+        xmlpp(
+          strip_guid(Asciidoctor.convert(input, backend: :standoc, header_footer: true))
+                      .gsub(%r{".+spec\/assets\/lutaml\/[^.\/]+\.}, %q("spec/assets/_.))))
+        .to(be_equivalent_to xmlpp(output))
+    end
+  end
+
+  context 'when lutaml_datamodel_attributes_table' do
+    let(:example_file) { fixtures_path("diagram_definitions.lutaml") }
+    let(:input) do
+      <<~"OUTPUT"
+        = Document title
+        Author
+        :docfile: test.adoc
+        :nodoc:
+        :novalid:
+        :no-isobib:
+        :imagesdir: spec/assets
+
+        [lutaml_datamodel_attributes_table,#{example_file},AttributeProfile]
+      OUTPUT
+    end
+    let(:output) do
+      <<~"OUTPUT"
+      #{BLANK_HDR}
+        <sections>
+          <clause id='_' inline-header='false' obligation='normative'>
+            <title>AttributeProfile</title>
+            <table id='_'>
+              <name>AttributeProfile attributes</name>
+              <thead>
+                <tr>
+                  <th valign='top' align='left'>Name</th>
+                  <th valign='top' align='left'>Definition</th>
+                  <th valign='top' align='left'>Mandatory/ Optional/ Conditional</th>
+                  <th valign='top' align='left'>Max Occur</th>
+                  <th valign='top' align='left'>Data Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td valign='top' align='left'>addressClassProfile</td>
+                  <td valign='top' align='left'>TODO: enum ‘s definition</td>
+                  <td valign='top' align='left'>M</td>
+                  <td valign='top' align='left'>1</td>
+                  <td valign='top' align='left'>
+                    <tt>CharacterString</tt>
+                  </td>
+                </tr>
+                <tr>
+                  <td valign='top' align='left'>imlicistAttributeProfile</td>
+                  <td valign='top' align='left'>this is attribute definition with multiply lines</td>
+                  <td valign='top' align='left'>M</td>
+                  <td valign='top' align='left'>1</td>
+                  <td valign='top' align='left'>
+                    <tt>CharacterString</tt>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </clause>
+        </sections>
+        </standard-document>
+      OUTPUT
+    end
+
+    it "processes the lutaml_diagram" do
+      expect(
+        xmlpp(
+          strip_guid(Asciidoctor.convert(input, backend: :standoc, header_footer: true))))
+        .to(be_equivalent_to(xmlpp(output)))
+    end
+  end
+
   it "processes the PlantUML macro with PlantUML disabled" do
     mock_plantuml_disabled
     expect { Asciidoctor.convert(<<~"INPUT", backend: :standoc, header_footer: true) }.to output(%r{PlantUML not installed}).to_stderr

--- a/spec/fixtures/diagram_definitions.lutaml
+++ b/spec/fixtures/diagram_definitions.lutaml
@@ -1,0 +1,22 @@
+diagram MyView {
+  title "my diagram"
+
+  enum AddressClassProfile {
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition
+        this is multiline with `ascidoc`
+        comments
+        and list
+      end definition
+    }
+  }
+
+  class AttributeProfile {
+    +addressClassProfile: CharacterString [0..1]
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition this is attribute definition
+      with multiply lines
+      end definition
+    }
+  }
+}


### PR DESCRIPTION
Depends on metanorma/metanorma-build-scripts#52