### PR TITLE
Handle FormulaIndexNotFoundError exception

### DIFF
--- a/spec/asciidoctor-standoc/converter_spec.rb
+++ b/spec/asciidoctor-standoc/converter_spec.rb
@@ -5,4 +5,17 @@ RSpec.describe Asciidoctor::Standoc do
     converter = Asciidoctor::Standoc::Converter.new(nil, backend: :standoc)
     expect(converter.flavor_name).to eql(:standoc)
   end
+
+  it "install TNR font (cold-run)" do
+    converter = Asciidoctor::Standoc::Converter.new(nil, backend: :standoc)
+
+    font_manifest = {
+      "Times New Roman" => nil,
+    }
+
+    VCR.turned_off do
+      WebMock.allow_net_connect!
+      converter.install_fonts_safe(font_manifest, true, false)
+    end
+  end
 end


### PR DESCRIPTION
### Intro

per @opoudjis 

> https://github.com/metanorma/metanorma-mpfa/runs/1616481310?check_suite_focus=true
> Which seems to indicate that "fontist update" needs to be added to cimas (I've just updated to fontist 1.8 from 1.7)

### Implementation

I think the initially proposed solution with `fontist update` step in GHA workflow will not work in packed-mn so we need to handle it in some gem

P.S. We also need a review from @alexeymorozov  too