### PR TITLE
Feature/add mn2pdf font manifest file attr

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,1 @@
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "improvement/remove-code-duplicate"

--- a/lib/asciidoctor/standoc/base.rb
+++ b/lib/asciidoctor/standoc/base.rb
@@ -84,7 +84,7 @@ module Asciidoctor
 
         if font_manifest_file = node.attr("mn2pdf-font-manifest-file")
           attrs[IsoDoc::XslfoPdfConvert::MN2PDF_OPTIONS] = {
-            IsoDoc::XslfoPdfConvert::MN2PDF_FONT_MANIFEST => font_manifest_file
+            IsoDoc::XslfoPdfConvert::MN2PDF_FONT_MANIFEST => font_manifest_file,
           }
         end
 

--- a/lib/asciidoctor/standoc/base.rb
+++ b/lib/asciidoctor/standoc/base.rb
@@ -8,6 +8,7 @@ require "isodoc"
 require "relaton"
 require "fileutils"
 require "metanorma-utils"
+require "isodoc/xslfo_convert"
 
 module Asciidoctor
   module Standoc
@@ -61,7 +62,7 @@ module Asciidoctor
       end
 
       def doc_extract_attributes(node)
-        {
+        attrs = {
           script: node.attr("script"),
           bodyfont: node.attr("body-font"),
           headerfont: node.attr("header-font"),
@@ -80,6 +81,14 @@ module Asciidoctor
           doctoclevels: node.attr("doctoclevels") || node.attr("toclevels"),
           break_up_urls_in_tables: node.attr("break-up-urls-in-tables"),
         }
+
+        if font_manifest_file = node.attr("mn2pdf-font-manifest-file")
+          attrs[IsoDoc::XslfoPdfConvert::MN2PDF_OPTIONS] = {
+            IsoDoc::XslfoPdfConvert::MN2PDF_FONT_MANIFEST => font_manifest_file
+          }
+        end
+
+        attrs
       end
 
       def doc_converter(node)

--- a/spec/asciidoctor/base_spec.rb
+++ b/spec/asciidoctor/base_spec.rb
@@ -787,6 +787,19 @@ QU1FOiB0ZXN0Cgo=
     expect(File.exist?("test.doc")).to be true
   end
 
+
+  it "process mn2pdf attributes" do
+    node = Nokogiri::XML("<fake/>").at("fake")
+    node["mn2pdf-font-manifest-file"] = "passed/as/font/manifest/to/mn2pdf.jar"
+
+    options = Asciidoctor::Standoc::Converter
+      .new(:standoc, header_footer: true)
+      .doc_extract_attributes(node)
+
+    expect(options.dig(:mn2pdf, :font_manifest_file))
+      .to eq(node["mn2pdf-font-manifest-file"])
+  end
+
   private
 
   def mock_org_abbrevs

--- a/spec/asciidoctor/base_spec.rb
+++ b/spec/asciidoctor/base_spec.rb
@@ -787,7 +787,6 @@ QU1FOiB0ZXN0Cgo=
     expect(File.exist?("test.doc")).to be true
   end
 
-
   it "process mn2pdf attributes" do
     node = Nokogiri::XML("<fake/>").at("fake")
     node["mn2pdf-font-manifest-file"] = "passed/as/font/manifest/to/mn2pdf.jar"


### PR DESCRIPTION
 - depends on https://github.com/metanorma/isodoc/pull/286

NOTE!!! `Gemfile.devel` commit should be reverted before merge