### PR TITLE
feat: move lutaml plugin initialization to gem

### DIFF
--- a/lib/metanorma/standoc/converter.rb
+++ b/lib/metanorma/standoc/converter.rb
@@ -25,9 +25,6 @@ module Metanorma
         preprocessor Metanorma::Standoc::Datamodel::DiagramPreprocessor
         preprocessor Metanorma::Plugin::Datastruct::Json2TextPreprocessor
         preprocessor Metanorma::Plugin::Datastruct::Yaml2TextPreprocessor
-        preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
-        preprocessor Metanorma::Plugin::Lutaml::LutamlUmlAttributesTablePreprocessor
-        preprocessor Metanorma::Plugin::Lutaml::LutamlUmlDatamodelDescriptionPreprocessor
         inline_macro Metanorma::Standoc::PreferredTermInlineMacro
         inline_macro Metanorma::Standoc::SpanInlineMacro
         inline_macro Metanorma::Standoc::AltTermInlineMacro
@@ -56,15 +53,11 @@ module Metanorma
         inline_macro Metanorma::Standoc::ToCInlineMacro
         inline_macro Metanorma::Standoc::PassInlineMacro
         inline_macro Metanorma::Standoc::StdLinkInlineMacro
-        inline_macro Metanorma::Plugin::Lutaml::LutamlFigureInlineMacro
-        inline_macro Metanorma::Plugin::Lutaml::LutamlTableInlineMacro
-        block_macro Metanorma::Plugin::Lutaml::LutamlDiagramBlockMacro
         block Metanorma::Standoc::ToDoAdmonitionBlock
         block Metanorma::Standoc::EditorAdmonitionBlock
         treeprocessor Metanorma::Standoc::EditorInlineAdmonitionBlock
         treeprocessor Metanorma::Standoc::ToDoInlineAdmonitionBlock
         block Metanorma::Standoc::PlantUMLBlockMacro
-        block Metanorma::Plugin::Lutaml::LutamlDiagramBlock
         block Metanorma::Standoc::PseudocodeBlockMacro
         preprocessor Metanorma::Standoc::EmbedIncludeProcessor
         preprocessor Metanorma::Standoc::NamedEscapePreprocessor


### PR DESCRIPTION
Fixes metanorma/metanorma-plugin-lutaml#82

Requires https://github.com/metanorma/metanorma-plugin-lutaml/pull/84

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
