### PR TITLE
Add support to handle font manifest properly

### DIFF
--- a/lib/metanorma/standoc/render.rb
+++ b/lib/metanorma/standoc/render.rb
@@ -82,7 +82,7 @@ module Metanorma
       end
 
       def pdf_extract_attributes(node)
-        %w(pdf-encrypt pdf-encryption-length pdf-user-password
+        pdf_options = %w(pdf-encrypt pdf-encryption-length pdf-user-password
            pdf-owner-password pdf-allow-copy-content pdf-allow-edit-content
            pdf-allow-assemble-document pdf-allow-edit-annotations
            pdf-allow-print pdf-allow-print-hq pdf-allow-fill-in-forms
@@ -91,6 +91,8 @@ module Metanorma
           .each_with_object({}) do |x, m|
           m[x.gsub(/-/, "").to_i] = node.attr(x)
         end
+
+        pdf_options.merge(fonts_manifest_option(node) || {})
       end
 
       def doc_converter(node)
@@ -119,6 +121,12 @@ module Metanorma
                                     nil, false, "#{@filename}.doc")
         pdf_converter(node)&.convert("#{@filename}.presentation.xml",
                                      nil, false, "#{@filename}.pdf")
+      end
+
+      def fonts_manifest_option(node)
+        if node.attr(FONTS_MANIFEST)
+          { mn2pdf: { font_manifest: node.attr(FONTS_MANIFEST) } }
+        end
       end
     end
   end

--- a/spec/metanorma/standoc/render_spec.rb
+++ b/spec/metanorma/standoc/render_spec.rb
@@ -1,0 +1,41 @@
+require "metanorma"
+require "spec_helper"
+
+RSpec.describe "TestRender" do
+  describe ".pdf_extract_attributes" do
+    it "extracts the font manifest when present" do
+      pdf_option_node = PdfOptionNode.new
+      pdf_options = TestRender.pdf_extract_attributes(pdf_option_node)
+
+      expect(pdf_options[:mn2pdf][:font_manifest]).to eq(
+        pdf_option_node.attr("fonts-manifest"),
+      )
+    end
+
+    it "does not inlcude the mn2pdf node when not present" do
+      pdf_option_node = PdfOptionNode.new
+      pdf_option_node.options["fonts-manifest"] = nil
+
+      pdf_options = TestRender.pdf_extract_attributes(pdf_option_node)
+
+      expect(pdf_options.fetch(:mn2pdf, nil)).to be_nil
+    end
+  end
+end
+
+class TestRender
+  extend Metanorma::Standoc::Base
+end
+
+class PdfOptionNode
+  attr_reader :options
+
+  def initialize(options = {})
+    @options = options
+    @options["fonts-manifest"] = "./tmp/fake-fontist-file"
+  end
+
+  def attr(key)
+    options.fetch(key, nil)
+  end
+end


### PR DESCRIPTION
**Context**:

Recently, we came across an issue where the collection pdf generation didn't not include the correct fonts and then it turns out the fontist manifest wasn't being passed around properly.

**Solutions**:

This commit adds that support to the core library, so all the dependent gems should be able to take advantage of that by passing the correct value and then it will use it properly.

Related:

- https://github.com/metanorma/bipm-si-brochure/issues/188