### PR TITLE
preserve relative link for attachments when compiling doc outside of …

### DIFF
--- a/lib/metanorma/standoc/cleanup_bibitem.rb
+++ b/lib/metanorma/standoc/cleanup_bibitem.rb
@@ -168,7 +168,8 @@ module Metanorma
 
       def valid_attachment?(path, bib)
         File.exist?(path) and return true
-        @log.add("Bibliography", bib, "Attachment #{path} does not exist",
+        p = Pathname.new(path).cleanpath
+        @log.add("Bibliography", bib, "Attachment #{p} does not exist",
                  severity: 0)
         false
       end

--- a/lib/metanorma/standoc/cleanup_bibitem.rb
+++ b/lib/metanorma/standoc/cleanup_bibitem.rb
@@ -160,10 +160,11 @@ module Metanorma
 
       def datauri_attachment(path, doc)
         @datauriattachment or return
-        n = add_misc_container(doc)
+        m = add_misc_container(doc)
         f = File.basename(path)
         d = Vectory::Utils::datauri(path, @localdir)
-        n << "<attachment name='#{f}'>#{d}</attachment>"
+        m << "<attachment name='#{f}'/>"
+        m.last_element_child << d
       end
 
       def valid_attachment?(path, bib)

--- a/lib/metanorma/standoc/cleanup_bibitem.rb
+++ b/lib/metanorma/standoc/cleanup_bibitem.rb
@@ -151,17 +151,17 @@ module Metanorma
         f = File.basename(path)
         File.exist?(File.join(@attachmentsdir, f)) and
           f += "_#{UUIDTools::UUID.random_create}"
-        ret = File.join(@attachmentsdir, f)
-        FileUtils.cp(path, ret)
-        datauri_attachment(ret, bib.document)
-        ret
+        out_fld = File.join(@attachmentsdir, f)
+        FileUtils.cp(path, out_fld)
+        datauri_attachment(out_fld, bib.document)
+        File.join(@attachmentsfld, f)
       end
 
       def datauri_attachment(path, doc)
         @datauriattachment or return
         n = add_misc_container(doc)
         f = File.basename(path)
-        d = Vectory::Utils.datauri(path)
+        d = Vectory::Utils::datauri(path, @localdir)
         n << "<attachment name='#{f}'>#{d}</attachment>"
       end
 
@@ -174,7 +174,8 @@ module Metanorma
 
       def init_attachments
         @attachmentsdir and return
-        @attachmentsdir = File.join(@output_dir, "_#{@filename}_attachments")
+        @attachmentsfld = "_#{@filename}_attachments"
+        @attachmentsdir = File.join(@output_dir, @attachmentsfld)
         FileUtils.rm_rf(@attachmentsdir)
         FileUtils.mkdir_p(@attachmentsdir)
       end

--- a/lib/metanorma/standoc/cleanup_bibitem.rb
+++ b/lib/metanorma/standoc/cleanup_bibitem.rb
@@ -147,6 +147,7 @@ module Metanorma
 
       def save_attachment(path, bib)
         init_attachments
+        path = File.join(@localdir, path)
         valid_attachment?(path, bib) or return ""
         f = File.basename(path)
         File.exist?(File.join(@attachmentsdir, f)) and

--- a/lib/metanorma/standoc/cleanup_text.rb
+++ b/lib/metanorma/standoc/cleanup_text.rb
@@ -35,7 +35,7 @@ module Metanorma
 
       IGNORE_QUOTES_ELEMENTS =
         %w(pre tt sourcecode stem asciimath figure bibdata passthrough
-           identifier presentation-metadata semantic-metadata).freeze
+           identifier metanorma-extension).freeze
 
       def uninterrupt_quotes_around_xml_skip(elem)
         !(/\A['"]/.match?(elem.text) &&

--- a/spec/assets/attach.adoc
+++ b/spec/assets/attach.adoc
@@ -1,0 +1,16 @@
+= Document title
+Author
+:docfile: attach.adoc
+:nodoc:
+:novalid:
+:no-isobib-cache:
+
+== Clause
+<<iso123>>
+
+[bibliography]
+== Normative References
+
+* [[[iso123,attachment:(spec/assets/iso.xml)]]]
+* [[[iso124,attachment:(spec/assets/iso.xml)]]]
+

--- a/spec/assets/attach.adoc
+++ b/spec/assets/attach.adoc
@@ -11,6 +11,6 @@ Author
 [bibliography]
 == Normative References
 
-* [[[iso123,attachment:(spec/assets/iso.xml)]]]
-* [[[iso124,attachment:(spec/assets/iso.xml)]]]
+* [[[iso123,attachment:(iso.xml)]]]
+* [[[iso124,attachment:(iso.xml)]]]
 

--- a/spec/examples/test.adoc
+++ b/spec/examples/test.adoc
@@ -1,0 +1,11 @@
+= Document title
+Author
+:docfile: test.adoc
+:nodoc:
+:novalid:
+:no-isobib:
+:data-uri-image: 
+
+.Split-it-right sample divider
+image::rice_images/rice_image1.png[]
+

--- a/spec/metanorma/blocks_spec.rb
+++ b/spec/metanorma/blocks_spec.rb
@@ -1431,6 +1431,10 @@ RSpec.describe Metanorma::Standoc do
     INPUT
     expect(strip_guid(Asciidoctor.convert(input, *OPTIONS)))
       .to include '<image src="data:image/png;base64'
+
+    FileUtils.rm_rf "test.xml"
+    system "bundle exec asciidoctor -b standoc -r metanorma-standoc spec/examples/test.adoc"
+    expect(File.read("test.xml")).to include '<image src="data:image/png;base64'
   end
 
   it "accepts attributes on paragraphs" do

--- a/spec/metanorma/blocks_spec.rb
+++ b/spec/metanorma/blocks_spec.rb
@@ -1432,9 +1432,9 @@ RSpec.describe Metanorma::Standoc do
     expect(strip_guid(Asciidoctor.convert(input, *OPTIONS)))
       .to include '<image src="data:image/png;base64'
 
-    FileUtils.rm_rf "test.xml"
+    FileUtils.rm_rf "spec/examples/test.xml"
     system "bundle exec asciidoctor -b standoc -r metanorma-standoc spec/examples/test.adoc"
-    expect(File.read("test.xml")).to include '<image src="data:image/png;base64'
+    expect(File.read("spec/examples/test.xml")).to include '<image src="data:image/png;base64'
   end
 
   it "accepts attributes on paragraphs" do

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -1174,18 +1174,7 @@ RSpec.describe Metanorma::Standoc do
   end
 
   it "processes attachments" do
-    input = <<~"INPUT"
-      #{ISOBIB_BLANK_HDR}
-
-      == Clause
-      <<iso123>>
-
-      [bibliography]
-      == Normative References
-
-      * [[[iso123,attachment:(spec/assets/iso.xml)]]]
-      * [[[iso124,attachment:(spec/assets/iso.xml)]]]
-    INPUT
+    input = File.read("spec/assets/attach.adoc")
     output = <<~OUTPUT
       <standard-document xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="#{Metanorma::Standoc::VERSION}">
          <bibdata type="standard">
@@ -1236,14 +1225,14 @@ RSpec.describe Metanorma::Standoc do
              <p id="_">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
              <bibitem id="iso123" hidden="true">
                <formattedref format="application/x-isodoc+xml">[NO INFORMATION AVAILABLE]</formattedref>
-               <uri type="attachment">./_test_attachments/iso.xml</uri>
-               <uri type="citation">./_test_attachments/iso.xml</uri>
+               <uri type="attachment">_attach_attachments/iso.xml</uri>
+               <uri type="citation">_attach_attachments/iso.xml</uri>
                <docidentifier type="metanorma">[spec/assets/iso.xml]</docidentifier>
              </bibitem>
              <bibitem id="iso124" hidden="true">
                <formattedref format="application/x-isodoc+xml">[NO INFORMATION AVAILABLE]</formattedref>
-               <uri type="attachment">./_test_attachments/iso.xml_</uri>
-               <uri type="citation">./_test_attachments/iso.xml_</uri>
+               <uri type="attachment">_attach_attachments/iso.xml_</uri>
+               <uri type="citation">_attach_attachments/iso.xml_</uri>
                <docidentifier type="metanorma">[spec/assets/iso.xml]</docidentifier>
              </bibitem>
            </references>
@@ -1262,6 +1251,13 @@ RSpec.describe Metanorma::Standoc do
       .gsub(/ICAgIC[^<]+/, "ICAgIC..."))))
       .to be_equivalent_to Xml::C14n.format(output
       .gsub(%r{<attachment .+?</attachment>}, ""))
+
+    FileUtils.rm_rf "spec/assets/attach.xml"
+    system "bundle exec asciidoctor -b standoc -r metanorma-standoc spec/assets/attach.adoc"
+    expect(Xml::C14n.format(strip_guid(File.read("spec/assets/attach.xml")
+      .gsub(/iso.xml_[a-f0-9-]+/, "iso.xml_")
+      .gsub(/ICAgIC[^<]+/, "ICAgIC..."))))
+      .to be_equivalent_to Xml::C14n.format(output)
   end
 
   private

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -1175,6 +1175,7 @@ RSpec.describe Metanorma::Standoc do
 
   it "processes attachments" do
     input = File.read("spec/assets/attach.adoc")
+      .gsub("iso.xml", "spec/assets/iso.xml")
     output = <<~OUTPUT
       <standard-document xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="#{Metanorma::Standoc::VERSION}">
          <bibdata type="standard">
@@ -1257,7 +1258,8 @@ RSpec.describe Metanorma::Standoc do
     expect(Xml::C14n.format(strip_guid(File.read("spec/assets/attach.xml")
       .gsub(/iso.xml_[a-f0-9-]+/, "iso.xml_")
       .gsub(/ICAgIC[^<]+/, "ICAgIC..."))))
-      .to be_equivalent_to Xml::C14n.format(output)
+      .to be_equivalent_to Xml::C14n.format(output
+      .gsub("spec/assets/iso.xml", "iso.xml"))
   end
 
   private

--- a/spec/metanorma/validate_spec.rb
+++ b/spec/metanorma/validate_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Metanorma::Standoc do
     rescue SystemExit, RuntimeError
     end
     expect(File.read("test.err.html"))
-      .to include %(Attachment ./hien/​spec_helper.​rb does not exist)
+      .to include %(Attachment hien/​spec_helper.​rb does not exist)
   end
 
   it "aborts on an index cross-reference with too few terms" do


### PR DESCRIPTION
…working directory; use document location when opening attachment to convert it to DataURI: https://github.com/metanorma/metanorma-standoc/issues/898

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
