### PR TITLE
Abort if designation markup is used in clause not recognised as term …

### DIFF
--- a/lib/metanorma/standoc/cleanup_section_names.rb
+++ b/lib/metanorma/standoc/cleanup_section_names.rb
@@ -144,12 +144,8 @@ module Metanorma
         sym and m[sym] += 1
       end
 
-      SECTION_CONTAINERS = %w(foreword introduction acknowledgements abstract
-                              clause clause references terms definitions annex
-                              appendix).freeze
-
       def sections_variant_title_cleanup(xml)
-        path = SECTION_CONTAINERS.map { |x| "./ancestor::#{x}" }.join(" | ")
+        path = section_containers.map { |x| "./ancestor::#{x}" }.join(" | ")
         xml.xpath("//p[@variant_title]").each do |p|
           p.name = "variant-title"
           p.delete("id")

--- a/lib/metanorma/standoc/utils.rb
+++ b/lib/metanorma/standoc/utils.rb
@@ -108,6 +108,15 @@ module Metanorma
           .gsub("&apos;", "'")
       end
 
+      SECTION_CONTAINERS =
+        %w(foreword introduction acknowledgements abstract
+           clause references terms definitions annex appendix indexsect 
+           executivesummary).freeze
+
+      def section_containers
+        SECTION_CONTAINERS
+      end
+
       # wrapped in <sections>
       def adoc2xml(text, flavour)
         Nokogiri::XML(text).root and return text

--- a/lib/metanorma/standoc/validate.rb
+++ b/lib/metanorma/standoc/validate.rb
@@ -21,13 +21,14 @@ module Metanorma
         concept_validate(doc, "concept", "refterm")
         concept_validate(doc, "related", "preferred//name")
         preferred_validate(doc)
+        termsect_validate(doc)
         table_validate(doc)
         requirement_validate(doc)
         image_validate(doc)
         math_validate(doc)
         fatalerrors = @log.abort_messages
         fatalerrors.empty? or
-          clean_abort(fatalerrors.join("\n"), doc)
+          clean_abort("\n\nFATAL ERRROS:\n\n#{fatalerrors.join("\n\n")}", doc)
       end
 
       MATHML_NS = "http://www.w3.org/1998/Math/MathML".freeze


### PR DESCRIPTION
…clause: https://github.com/metanorma/metanorma-standoc/issues/959

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
