### PR TITLE
fix: Guard against target nil in xref_compound_cleanup

### DIFF
--- a/lib/metanorma/cleanup/xref.rb
+++ b/lib/metanorma/cleanup/xref.rb
@@ -87,7 +87,8 @@ module Metanorma
 
       def xref_compound_cleanup(xmldoc)
         xmldoc.xpath("//xref").each do |x|
-          x["target"].include?(";") or next
+          next unless x["target"]&.include?(";")
+          
           locations = x["target"].split(";")
           x["target"] = locations.first.sub(/^[^!]*!/, "")
           xref_compound_cleanup1(x, locations)


### PR DESCRIPTION
Fixes #1174

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
