### PR TITLE
indexterm: escape raw <> in term text: https://github.com/metanorma/metanorma-iso/issues/1553

### DIFF
--- a/lib/metanorma/converter/inline.rb
+++ b/lib/metanorma/converter/inline.rb
@@ -200,7 +200,7 @@ module Metanorma
       end
 
       def inline_indexterm_extract(node)
-        terms = (node.attr("terms") || [node.text]).map { |x| xml_encode(x) }
+        terms = node.attr("terms") || [node.text]
         see = node.attr("see")
         also = node.attr("see-also")
         [terms, see, also]

--- a/spec/metanorma/inline_spec.rb
+++ b/spec/metanorma/inline_spec.rb
@@ -999,11 +999,14 @@ RSpec.describe Metanorma::Standoc do
     input = <<~INPUT
       #{ASCIIDOC_BLANK_HDR}
       ((See)) Index ((_term_)) and(((A~B~, stem:[alpha], &#x2c80;))).
+
+      Raw brackets: (((energy <thermodynamics>))) and(((alpha, beta <foo>, gamma~x~))).
     INPUT
     output = <<~OUTPUT
          #{BLANK_HDR}
         <sections>
         <p id="_">See<index><primary>See</primary></index> Index <em>term</em><index><primary><em>term</em></primary></index> and<index><primary>A<sub>B</sub></primary><secondary><stem type="MathML" block="false"><math xmlns="http://www.w3.org/1998/Math/MathML"><mstyle displaystyle="false"><mi>α</mi></mstyle></math><asciimath>alpha</asciimath></stem></secondary><tertiary>Ⲁ</tertiary></index>.</p>
+        <p id="_">Raw brackets: <index><primary>energy &lt;thermodynamics&gt;</primary></index> and<index><primary>alpha</primary><secondary>beta &lt;foo&gt;</secondary><tertiary>gamma<sub>x</sub></tertiary></index>.</p>
         </sections>
       </metanorma>
     OUTPUT


### PR DESCRIPTION
Fixes https://github.com/metanorma/metanorma-iso/issues/1553.

Full diagnosis and rationale on the ticket; in short, `inline_indexterm_extract` was the only inline-handling path running term text through `xml_encode`, whose strip-back gsubs were re-creating raw `<`/`>` out of the already-correctly-escaped text asciidoctor delivers. Other inline positions (paragraph, `<strong>`, footnote, link, …) already handle this cleanly via the native `node.text` → Nokogiri-builder pipeline; this change brings indexterm into line.

The existing `(((A~B~, stem:[alpha], &#x2c80;)))` regression case continues to pass — asciidoctor's own inline substitutions still flow through as real markup. New assertions cover `(((energy <thermodynamics>)))` (the Liquid-shaped case from the ticket) and the multi-term mixed form `(((alpha, beta <foo>, gamma~x~)))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
