### PR TITLE
Respect explicit Asciidoc smart-quote markup under both smartquotes modes: https://github.com/metanorma/metanorma-standoc/issues/1182

### DIFF
--- a/lib/metanorma/converter/inline.rb
+++ b/lib/metanorma/converter/inline.rb
@@ -89,8 +89,8 @@ module Metanorma
           when :emphasis then xml.em { |s| s << node.text }
           when :strong then xml.strong { |s| s << node.text }
           when :monospaced then xml.tt { |s| s << node.text }
-          when :double then xml << "\"#{node.text}\""
-          when :single then xml << "'#{node.text}'"
+          when :double then xml << "“#{node.text}”"
+          when :single then xml << "‘#{node.text}’"
           when :superscript then xml.sup { |s| s << node.text }
           when :subscript then xml.sub { |s| s << node.text }
           when :asciimath then stem_parse(node.text, xml, :asciimath, node)

--- a/lib/metanorma/converter/macros_nosub.rb
+++ b/lib/metanorma/converter/macros_nosub.rb
@@ -116,7 +116,7 @@ module Metanorma
         p = Metanorma::Utils::LineStatus.new
         lines = reader.lines.map do |t|
           p.process(t)
-          !p.pass && t.include?("`") ? inlinemonospace(t) : t
+          !p.pass && /(?<!")`(?!")/.match?(t) ? inlinemonospace(t) : t
         end
         ::Asciidoctor::PreprocessorReader.new document, lines
       end
@@ -145,10 +145,10 @@ module Metanorma
       # Regex to match single or double backticks with content
       # Matches: `text` or ``text``
       # Avoids: escaped backticks \`
-      MonospaceRx = /(?<!\\)(`{1,2})(.+?)(?<!\\)\1/
+      MonospaceRx = /(?<![\\"])(`{1,2})(?!")(.+?)(?<!\\)\1/
 
       def inlinemonospace(text)
-        text.include?("`") or return text
+        /(?<!")`(?!")/.match?(text) or return text
         /^\[.*\]\s*$/.match?(text) and return text
         pass_inline_split(text) do |x|
           monospace_escape(x)


### PR DESCRIPTION
Honours explicit Asciidoc smart-quote markup `"`...`"` / `'`...`'` under both
`:smartquotes:` modes.

Full diagnosis (root cause, why it regressed in 2021, fix rationale) in the
issue: https://github.com/metanorma/metanorma-standoc/issues/1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
