### PR TITLE
:flush-caches: no longer no-ops when :no-isobib-cache: is also set

### DIFF
--- a/lib/metanorma/converter/ref_queue.rb
+++ b/lib/metanorma/converter/ref_queue.rb
@@ -221,11 +221,30 @@ module Metanorma
         global = !@no_isobib_cache && !node.attr("local-cache-only")
         local = node.attr("local-cache") || node.attr("local-cache-only")
         local = nil if @no_isobib_cache
+        flush_bib_caches_force(node) if node.attr("flush-caches") &&
+          @no_isobib_cache
         @bibdb = Relaton::Db.init_bib_caches(
           local_cache: local,
           flush_caches: node.attr("flush-caches"),
           global_cache: global,
         )
+      end
+
+      # `:flush-caches:` must clear stale cache state regardless of whether
+      # `:no-isobib-cache:` disables caching for *this* compile. When both
+      # are set, the `Relaton::Db.init_bib_caches` path no-ops on the flush
+      # (because it has no cache paths to flush), leaving any previously
+      # cached entries on disk for the next compile that DOES have caching
+      # enabled to pick up. Force-flush the conventional cache locations
+      # here so the flag does what its name says.
+      # Source issue: https://github.com/relaton/relaton-iso/issues/181
+      def flush_bib_caches_force(node)
+        FileUtils.rm_rf "#{Dir.home}/.relaton/cache"
+        lcache_name = node.attr("local-cache") || node.attr("local-cache-only")
+        if lcache_name
+          base = lcache_name.to_s.empty? ? "relaton" : lcache_name
+          FileUtils.rm_rf "#{base}/cache"
+        end
       end
 
       # Treat empty strings as falsy (they're set by Asciidoctor for some attributes)

--- a/spec/metanorma/isobib_cache_spec.rb
+++ b/spec/metanorma/isobib_cache_spec.rb
@@ -426,6 +426,48 @@ RSpec.describe Metanorma::Standoc do
     # File.expand_path("~/.iev/cache"), force: true
   end
 
+  it "flushes biblio caches even when :no-isobib-cache: is also set" do
+    # https://github.com/relaton/relaton-iso/issues/181 — `:flush-caches:`
+    # was a silent no-op when `:no-isobib-cache:` was also set, because
+    # both global and local cache paths became nil and Relaton::Db's
+    # flush_caches(nil, nil) did nothing. Stale cache state from prior
+    # compiles persisted on disk regardless.
+    relaton_bib_file  = File.expand_path("~/.relaton/cache")
+    relaton_bib_file1 = File.expand_path("~/.relaton-bib.pstore1")
+    FileUtils.rm_rf relaton_bib_file1
+    File.exist?(relaton_bib_file) and
+      FileUtils.mv relaton_bib_file, relaton_bib_file1
+
+    # Plant stale content at the global cache location.
+    FileUtils.mkdir_p File.dirname(relaton_bib_file)
+    File.write(relaton_bib_file, "XXX")
+
+    Asciidoctor.convert(<<~INPUT, *OPTIONS)
+      = Document title
+      Author
+      :docfile: test.adoc
+      :nodoc:
+      :novalid:
+      :no-isobib-cache:
+      :flush-caches:
+
+      [bibliography]
+      == Normative References
+
+      * [[[iso123,ISO 123:2001]]] _Standard_
+    INPUT
+
+    # The stale "XXX" must be gone. `:no-isobib-cache:` means no fresh
+    # cache is written during the compile either, so the path should not
+    # exist at all afterwards.
+    expect(File.exist?(relaton_bib_file)).to be false
+
+    FileUtils.rm_rf relaton_bib_file
+    if File.exist?(relaton_bib_file1)
+      FileUtils.mv relaton_bib_file1, relaton_bib_file, force: true
+    end
+  end
+
   it "does not fetch references for ISO references in preparation" do
     FileUtils.mv File.expand_path("~/.relaton/cache"),
                  File.expand_path("~/.relaton-bib.pstore1"), force: true


### PR DESCRIPTION
Refs https://github.com/relaton/relaton-iso/issues/181

When both `:no-isobib-cache:` and `:flush-caches:` are set on a document, `init_bib_caches` derives `local = nil` and `global = false`, hands those to `Relaton::Db.init_bib_caches`, and the resulting `flush_caches(nil, nil)` deletes nothing. Stale cache state from a previous compile that had caching enabled persists on disk and is read by the next compile that re-enables caching.

The flag combination wasn't designed for, but if the author asks for both, "flush" should still mean "remove stale state from disk". Force-flush the conventional cache locations (`~/.relaton/cache` and the `:local-cache:` / `:local-cache-only:` directory if either is set) when `:flush-caches:` runs alongside `:no-isobib-cache:`.

Surfaced during diagnosis of relaton-iso#181 (a separate root-cause hypothesis on the actual bug, see issue thread) — but the no-op is real and worth fixing on its own.

Regression spec at `spec/metanorma/isobib_cache_spec.rb` asserts the global cache file is gone after a `:flush-caches: + :no-isobib-cache:` compile.
