### PR TITLE
Add extract to title_nums_prep

### DIFF
--- a/lib/metanorma/converter/front_title.rb
+++ b/lib/metanorma/converter/front_title.rb
@@ -55,7 +55,8 @@ module Metanorma
         { part:, subpart:, amendment: node.attr("amendment-number"),
           corrigendum: node.attr("corrigendum-number"),
           addendum: node.attr("addendum-number"),
-          supplement: node.attr("supplement-number") }
+          supplement: node.attr("supplement-number"),
+          extract: node.attr("extract-number") }
       end
 
       def title_num_prefix(key, value, xml, lang)


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/1562

Adds `extract: node.attr("extract-number")` to `title_nums_prep`, emitting the `project-number/@extract` attribute and the `title-extract-prefix` for the ISO Extract doctype. Exact mirror of the supplement entry; consumed by metanorma-iso's Extract support.

🤖
