### PR TITLE
Pass table custom class through to Semantic XML

### DIFF
--- a/lib/metanorma/converter/table.rb
+++ b/lib/metanorma/converter/table.rb
@@ -9,7 +9,11 @@ module Metanorma
                  plain: node.option?("plain") ? "true" : nil,
                  style: node.attr("css-style"),
                  summary: node.attr("summary"),
-                 width: node.attr("width"))
+                 width: node.attr("width"),
+                 # Custom CSS class(es) passed through to HTML output, via the
+                 # `[class="..."]` named attribute (NOT role, which is reserved
+                 # for block dispatch). metanorma/metanorma-pdfa#33
+                 class: node.attr("class"))
       end
 
       def table(node)

--- a/lib/metanorma/validate/isodoc.rng
+++ b/lib/metanorma/validate/isodoc.rng
@@ -844,6 +844,12 @@ titlecase, or lowercase</a:documentation>
         <a:documentation>CSS style: only background-color, color, border supported</a:documentation>
       </attribute>
     </optional>
+    <optional>
+      <attribute name="class">
+        <a:documentation>Custom CSS class(es), space-separated, appended to the HTML table
+class (HTML output only). See metanorma/metanorma-pdfa#33</a:documentation>
+      </attribute>
+    </optional>
     <ref name="BlockAttributes"/>
   </define>
   <define name="FigureAttributes" combine="interleave">

--- a/spec/metanorma/table_spec.rb
+++ b/spec/metanorma/table_spec.rb
@@ -1,6 +1,47 @@
 require "spec_helper"
 
 RSpec.describe Metanorma::Standoc do
+  # metanorma/metanorma-pdfa#33: a table's `[class="..."]` named attribute is
+  # passed through to Semantic XML `@class` (and thence to the HTML class). The
+  # `role` attribute is deliberately NOT used for this -- role is a reserved
+  # block-dispatch vocabulary, so honouring it as a CSS class would not be
+  # backward compatible.
+  it "passes a table's custom class through to Semantic XML" do
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+      [class="sortable"]
+      |===
+      |A |B
+      |===
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    expect(xml.at("//xmlns:table")["class"]).to eq "sortable"
+  end
+
+  it "passes multiple space-separated table classes through verbatim" do
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+      [class="sortable fixed"]
+      |===
+      |A |B
+      |===
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    expect(xml.at("//xmlns:table")["class"]).to eq "sortable fixed"
+  end
+
+  it "does NOT turn a table's role into a class (backward compatibility)" do
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+      [role="sortable"]
+      |===
+      |A |B
+      |===
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    expect(xml.at("//xmlns:table")["class"]).to be_nil
+  end
+
   it "processes basic tables" do
     input = <<~INPUT
       #{ASCIIDOC_BLANK_HDR}


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/33

Pass a table's `[class="..."]` named attribute through to Semantic XML `@class`, and bundle the regenerated `isodoc.rng` that validates it. `role` is deliberately not used — it is a reserved block-dispatch vocabulary, so honouring it as a CSS class would not be backward compatible. Regression specs added (passthrough, multiple classes, and a guard that `[role=]` does not become a class). Full narrative on the issue.

🤖
