### PR TITLE
Run monospace safeguard after content-injecting preprocessors

### DIFF
--- a/lib/metanorma/converter/converter.rb
+++ b/lib/metanorma/converter/converter.rb
@@ -40,11 +40,16 @@ module Metanorma
         preprocessor Metanorma::Standoc::EmbedIncludeProcessor
         preprocessor Metanorma::Standoc::LinkProtectPreprocessor
         preprocessor Metanorma::Standoc::PassProtectPreprocessor
-        preprocessor Metanorma::Standoc::MonospaceProtectPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::Json2TextPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::Yaml2TextPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::Data2TextPreprocessor
         preprocessor Metanorma::Plugin::Lutaml::LutamlXmiUmlPreprocessor
+        # MonospaceProtect must run AFTER the content-injecting preprocessors
+        # (json2text/yaml2text/data2text, XMI) so that monospace in their
+        # injected content is protected from Asciidoctor character
+        # substitution too, consistently with hand-authored adoc.
+        # metanorma/iso-10303#208
+        preprocessor Metanorma::Standoc::MonospaceProtectPreprocessor
         preprocessor Metanorma::Plugin::Glossarist::DatasetPreprocessor
         preprocessor Metanorma::Standoc::NamedEscapePreprocessor
         inline_macro Metanorma::Standoc::PreferredTermInlineMacro

--- a/spec/metanorma/preprocessor_ordering_spec.rb
+++ b/spec/metanorma/preprocessor_ordering_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+# Regression guard for preprocessor ORDERING.
+#
+# metanorma's monospace safeguard (MonospaceProtectPreprocessor) must run
+# AFTER the content-injecting preprocessors (yaml2text / json2text /
+# data2text / lutaml*), so that monospace inside their *injected* content is
+# protected from Asciidoctor character substitution exactly like
+# hand-authored monospace. The relative timing of these preprocessors is
+# load-bearing: if the guard is registered before the injectors, injected
+# `->` becomes `→`, `--` becomes an em dash, and a `\->` escape is
+# consumed -- see metanorma/iso-10303#208.
+#
+# These examples fail loudly if that ordering ever regresses.
+RSpec.describe "preprocessor ordering: monospace safeguard covers injected content" do
+  around do |example|
+    File.write("ordering_spec.yaml", { "sym" => "->" }.to_yaml)
+    example.run
+    FileUtils.rm_rf("ordering_spec.yaml")
+  end
+
+  let(:input) do
+    <<~INPUT
+      = Document title
+      Author
+      :docfile: test.adoc
+      :nodoc:
+      :novalid:
+      :no-isobib:
+
+      handauthored:: arrow `->` dash `--` ellipsis `...`
+
+      [yaml2text,ordering_spec.yaml,ctx]
+      ----
+      injected:: arrow `->` dash `--` ellipsis `...` interp `{ctx.sym}`
+      ----
+    INPUT
+  end
+
+  let(:output) do
+    Asciidoctor.convert(input, backend: :standoc, header_footer: true)
+  end
+
+  it "safeguards monospace injected by yaml2text like hand-authored monospace" do
+    # hand-authored monospace is the baseline: always literal
+    expect(output).to include("<tt>-&gt;</tt>")
+
+    # the guarantee: injected monospace is safeguarded identically, so the
+    # literal monospace `->` appears BOTH hand-authored and injected (and the
+    # interpolated {ctx.sym} == "->" makes a third). If the guard ran before
+    # yaml2text, the injected ones would be substituted and this count drops.
+    expect(output.scan("<tt>-&gt;</tt>").size).to be >= 3
+
+    # no character substitution leaked out of any monospace span
+    expect(output).not_to include("→") # -> right arrow
+    expect(output).not_to include("&#8594;") # -> right arrow (entity)
+    expect(output).not_to include("—") # -- em dash
+    expect(output).not_to include("…") # ... ellipsis
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/208

Make metanorma's monospace safeguard cover **preprocessor-injected** content, not just hand-authored AsciiDoc.

`MonospaceProtectPreprocessor` wraps monospace in `pass:c,q,a,m,p[…]` (deliberately withholding the `replacements` substitution) so monospace stays literal. But it was registered **before** the content-injecting preprocessors — `json2text`/`yaml2text`/`data2text` and the XMI preprocessor — so their injected monospace slipped past the guard and fell back to stock Asciidoctor substitution (e.g. `` `->` `` → `→`, and `` `\->` `` → `->` with the escape consumed). This is the missing-backslash report in iso-10303#208.

Fix: move `MonospaceProtectPreprocessor` to run **after** those injectors, so injected monospace is safeguarded consistently with hand-authored adoc. `LinkProtect`/`PassProtect` remain before the injectors (unchanged); `NamedEscapePreprocessor` remains after the guard (unchanged).

Full diagnosis, minimal reproduction, and the author-facing warning (this changes output for templates that relied on the old unprotected behaviour) are on iso-10303#208.

## Test plan
- Targeted specs green: `macros_yaml2text_spec`, `macros_json2text_spec`, `inline_monospace_spec`, `macros_spec` — 52 examples, 0 failures.
- Full suite: 522 examples, **3 failures — all pre-existing on `main`** (they fail identically with this change stashed): `refs_spec:989` (attachments), `base_spec:1514` (asciidoc.log preprocessing dump), `blocks_spec:1399` (images as datauri). In this local env they stem from an unrelated shell-out/encoding issue; **to be confirmed on CI and debugged jointly on this PR** — not addressed here.

🤖
