### PR TITLE
Add :bibliography-cutoff-date: override for the bibliographic cutoff

### DIFF
--- a/lib/metanorma/converter/init.rb
+++ b/lib/metanorma/converter/init.rb
@@ -197,6 +197,15 @@ module Metanorma
       end
 
       def biblio_cutoff(node)
+        # An explicit :bibliography-cutoff-date: overrides the date derived from
+        # the document's own dates, and a sentinel (none/false/no/off) disables
+        # the cutoff entirely. metanorma/metanorma-standoc#941.
+        if (override = node.attr("bibliography-cutoff-date"))
+          override = override.strip
+          return nil if %w(none false no off).include?(override.downcase)
+
+          return complete_and_compare_dates([override])
+        end
         dates = %w(revdate published-date accessed-date created-date
                    implemented-date confirmed-date updated-date issued-date
                    circulated-date unchanged-date copyright-year)

--- a/spec/metanorma/refs_fetch_spec.rb
+++ b/spec/metanorma/refs_fetch_spec.rb
@@ -1967,4 +1967,34 @@ RSpec.describe Metanorma::Standoc do
     ident = xml.at("//xmlns:bibitem[@anchor='iso123']/xmlns:docidentifier[@type='IEC']")
     expect(ident.text).to eq("IEC 80000-6:2008")
   end
+
+  # metanorma/metanorma-standoc#941: :bibliography-cutoff-date: overrides the
+  # cutoff derived from the document's own dates.
+  it "bibliography-cutoff-date attribute sets the cutoff without a document date" do
+    input = <<~"INPUT"
+      #{ISOBIB_BLANK_HDR.sub(':nodoc:', ":nodoc:\n:bibliography-cutoff-date: 2019")}
+
+      [bibliography]
+      == Normative References
+
+      * [[[iso123,IEC 80000-6]]]
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    ident = xml.at("//xmlns:bibitem[@anchor='iso123']/xmlns:docidentifier[@type='IEC']")
+    expect(ident.text).to eq("IEC 80000-6:2008")
+  end
+
+  it "bibliography-cutoff-date: none disables the cutoff derived from document dates" do
+    input = <<~"INPUT"
+      #{ISOBIB_BLANK_HDR.sub(':nodoc:', ":nodoc:\n:published-date: 2019\n:bibliography-cutoff-date: none")}
+
+      [bibliography]
+      == Normative References
+
+      * [[[iso123,IEC 80000-6]]]
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    ident = xml.at("//xmlns:bibitem[@anchor='iso123']/xmlns:relation[@type = 'instanceOf']/xmlns:bibitem/xmlns:docidentifier[@type='IEC']")
+    expect(ident.text).to eq("IEC 80000-6:2022")
+  end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/issues/941

Adds a `:bibliography-cutoff-date:` document attribute that overrides the bibliographic cutoff otherwise derived from the document's own dates (revdate/copyright-year/…). A sentinel value (`none`/`false`/`no`/`off`) disables the cutoff entirely.

This is the "or an override" half of #941 — the reference status/edition rewind is driven by the cutoff, and some documents need to set it explicitly rather than have it inferred. Specs cover both the override-sets-cutoff and override-disables cases.

Companion PRs: relaton/relaton-iso#190 (rewind fetched status under the cutoff) and metanorma/metanorma-iso#1577 (date-gate the ISO withdrawn/under-preparation annotations). The new attribute will be documented on metanorma.org.

🤖
