### PR TITLE
Emit custom @class on definition lists (dl)

### DIFF
--- a/lib/metanorma/converter/lists.rb
+++ b/lib/metanorma/converter/lists.rb
@@ -103,6 +103,7 @@ module Metanorma
           .merge(
             metadata: node.option?("metadata") ? "true" : nil,
             key: node.option?("key") ? "true" : nil,
+            class: node.attr("class"),
           )))
       end
 

--- a/spec/metanorma/lists_spec.rb
+++ b/spec/metanorma/lists_spec.rb
@@ -75,6 +75,43 @@ RSpec.describe Metanorma::Standoc do
     OUTPUT
   end
 
+  it "passes the custom class attribute through on lists (ul, ol, dl)" do
+    output = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+      #{ASCIIDOC_BLANK_HDR}
+      [class="ul-class"]
+      * List 1
+      * List 2
+
+      [class="ol-class"]
+      . List A
+      . List B
+
+      [class="dl-class"]
+      List D:: List E
+      List F:: List G
+    INPUT
+    expect(strip_guid(output)).to be_xml_equivalent_to <<~"OUTPUT"
+        #{BLANK_HDR}
+        <sections>
+          <ul id="_" class="ul-class">
+            <li><p id="_">List 1</p></li>
+            <li><p id="_">List 2</p></li>
+          </ul>
+          <ol id="_" type="arabic" class="ol-class">
+            <li><p id="_">List A</p></li>
+            <li><p id="_">List B</p></li>
+          </ol>
+          <dl id="_" class="dl-class">
+            <dt>List D</dt>
+            <dd id="_"><p id="_">List E</p></dd>
+            <dt>List F</dt>
+            <dd id="_"><p id="_">List G</p></dd>
+          </dl>
+        </sections>
+      </metanorma>
+    OUTPUT
+  end
+
   it "processes complex lists" do
     input = <<~INPUT
       #{ASCIIDOC_BLANK_HDR}


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/712

## Summary

Adds custom `@class` passthrough to **definition lists (dl)** — the one block the block-custom-class saga (metanorma/metanorma-standoc#1197) missed. Surfaced via iso-10303#712 (an author wanting to restyle dls).

`dl_attrs` now emits `class: node.attr("class")`, identical to `ul_attrs`/`ol_attrs`, so an author's `[class="…"]` on a definition list flows to Semantic XML `<dl class="…">`. The grammar (`DlAttributes = BlockAttributes`, which carries `class`) already permitted it and isodoc's `dl_attrs` already renders it — only the standoc emit was missing.

## Changes
- `lib/metanorma/converter/lists.rb` — `dl_attrs` emits `class`.
- `spec/metanorma/lists_spec.rb` — new test: `[class="…"]` on ul, ol, **and** dl → `<ul/ol/dl class="…">`.

Full `lists_spec` green (4/0).

🤖
