### PR TITLE
Add configurable publisher bibliography sort order

### DIFF
--- a/lib/metanorma/cleanup/cleanup.rb
+++ b/lib/metanorma/cleanup/cleanup.rb
@@ -61,7 +61,7 @@ module Metanorma
           boilerplateauthority embed_hdr embed_id erefstyle originstyle
           xrefstyle blockunnumbered keepasciimath numberfmt_formula
           numberfmt_prof sort_biblio reqt_models default_requirement_model
-          document_scheme
+          document_scheme publisher_sort_config
         ]
       end
 

--- a/lib/metanorma/cleanup/ref.rb
+++ b/lib/metanorma/cleanup/ref.rb
@@ -34,6 +34,77 @@ module Metanorma
         bib
       end
 
+      BIBLIO_PUBLISHER_ORG =
+        "./contributor[role/@type = 'publisher']/organization".freeze
+
+      # Configurable publisher sort ranking, shared by every flavour's
+      # bibliography sort. `table` is the flavour's default ordering, an array
+      # of { abbrev:, name:, rank: }. A per-document / metanorma-taste override
+      # (:sort-biblio-<abbrev>: <rank>: <name> attributes, captured into
+      # @publisher_sort_config) REPLACES the flavour default when present.
+      #
+      # A matched publisher gets its configured rank; an unmatched standards
+      # reference sorts immediately after the ranked publishers, and a
+      # non-standard reference last. With no override and the flavour's own
+      # default table, this reproduces the flavour's historical hardcoded ranks.
+      def publisher_sort_rank(bib, table)
+        table = publisher_sort_table(table)
+        if (entry = publisher_sort_match(bib, table))
+          return entry[:rank]
+        end
+
+        maxrank = table.map { |e| e[:rank] }.max || 0
+        biblio_standards_ref?(bib) ? maxrank + 1 : maxrank + 2
+      end
+
+      # Secondary sort token: the co-publisher(s) other than the matched
+      # primary. Deterministic when several co-publishers exist (returns the
+      # smallest token), which reproduces e.g. JIS's "JIS+IEC before
+      # JIS+ISO, JIS+IEC+ISO alongside JIS+IEC" ordering.
+      def publisher_sort_second(bib, table)
+        entry = publisher_sort_match(bib, publisher_sort_table(table))
+        entry or return ""
+        bib.xpath(BIBLIO_PUBLISHER_ORG)
+          .reject { |o| publisher_org_match?(o, entry) }
+          .map { |o| (o.at("./abbreviation") || o.at("./name"))&.text&.strip }
+          .compact.reject(&:empty?).min || ""
+      end
+
+      def publisher_sort_table(default_table)
+        cfg = @publisher_sort_config
+        cfg && !cfg.empty? ? cfg : default_table
+      end
+
+      # lowest-ranked table entry whose publisher appears on the bibitem
+      def publisher_sort_match(bib, table)
+        orgs = bib.xpath(BIBLIO_PUBLISHER_ORG)
+        table.sort_by { |e| e[:rank] }.find do |e|
+          orgs.any? { |o| publisher_org_match?(o, e) }
+        end
+      end
+
+      # A table entry matches a publisher organization on its abbreviation
+      # (case-insensitive, since AsciiDoc lowercases attribute-derived abbrevs)
+      # or on any of its names (`name` may be a single string or an array; the
+      # latter lets a flavour list, e.g., a Japanese and an English publisher
+      # name for the same rank).
+      def publisher_org_match?(org, entry)
+        abbr = org.at("./abbreviation")&.text&.strip
+        name = org.at("./name")&.text&.strip
+        names = Array(entry[:name]).map { |n| n.to_s.strip }.reject(&:empty?)
+        (!entry[:abbrev].to_s.empty? && abbr&.casecmp?(entry[:abbrev])) ||
+          (!name.to_s.empty? && names.include?(name))
+      end
+
+      # Whether a bibitem is a standards reference (sorts after the ranked
+      # publishers, before non-standard references). Base definition: it has a
+      # typed, non-DOI/ISSN/ISBN docidentifier. Flavours may widen this (ISO
+      # also treats an untyped docidentifier as a standards reference).
+      def biblio_standards_ref?(bib)
+        !!bib.at("./docidentifier[@type][not(#{@conv.skip_docid} or " \
+                 "@type = 'metanorma')]")
+      end
+
       # default presuppose that all citations in biblio numbered
       # consecutively, but that standards codes are preserved as is:
       # only numeric references are renumbered

--- a/lib/metanorma/converter/init.rb
+++ b/lib/metanorma/converter/init.rb
@@ -183,11 +183,27 @@ module Metanorma
         @no_isobib = node.attr("no-isobib")
         @flush_caches = node.attr("flush-caches")
         @sort_biblio = node.attr("sort-biblio") != "false"
+        @publisher_sort_config = init_publisher_sort_config(node)
         init_bib_db(node)
         init_bib_caches(node)
         init_iev_caches(node)
         init_bib_log
         @biblio_cutoff = biblio_cutoff(node)
+      end
+
+      # Per-publisher bibliography sort ranks, from
+      # :sort-biblio-<abbrev>: <rank>: <name> document attributes (set directly
+      # in a document or injected by a metanorma-taste config). AsciiDoc
+      # lowercases attribute names, so <abbrev> is matched case-insensitively
+      # downstream. Returns [] when none are set (flavours keep their default
+      # publisher ordering).
+      def init_publisher_sort_config(node)
+        node.attributes.each_with_object([]) do |(k, v), acc|
+          m = /\Asort-biblio-(?<abbrev>.+)\z/.match(k.to_s) or next
+          rank_s, name = v.to_s.split(":", 2)
+          rank = Integer(rank_s.to_s.strip, exception: false) or next
+          acc << { abbrev: m[:abbrev].strip, name: name&.strip, rank: rank }
+        end
       end
 
       def init_bib_db(node)

--- a/spec/metanorma/publisher_sort_spec.rb
+++ b/spec/metanorma/publisher_sort_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+# Shared, configurable publisher bibliography-sort helpers (metanorma-oiml#12).
+# The base standoc sort is a no-op; these helpers are exercised by every
+# flavour's sort_biblio and are unit-tested here in isolation.
+RSpec.describe Metanorma::Standoc::Ref do
+  # Minimal host object mixing in the helpers, with a converter stub supplying
+  # #skip_docid (the DOI/ISSN/ISBN exclusion xpath fragment).
+  let(:host) do
+    conv = Struct.new(:skip_docid).new(
+      "@type = 'DOI' or @type = 'doi'",
+    )
+    Class.new do
+      include Metanorma::Standoc::Ref
+      attr_accessor :publisher_sort_config
+      def initialize(conv) = (@conv = conv)
+    end.new(conv)
+  end
+
+  DEFAULT = [
+    { abbrev: "ISO", name: "International Organization for Standardization",
+      rank: 1 },
+    { abbrev: "IEC", name: "International Electrotechnical Commission",
+      rank: 2 },
+  ].freeze
+
+  # Build a <bibitem> with the given publisher orgs (each {abbrev:, name:}) and
+  # an optional typed docidentifier.
+  def bibitem(*publishers, docid: nil)
+    pubs = publishers.map do |p|
+      abbr = p[:abbrev] ? "<abbreviation>#{p[:abbrev]}</abbreviation>" : ""
+      name = p[:name] ? "<name>#{p[:name]}</name>" : ""
+      "<contributor><role type='publisher'/>" \
+        "<organization>#{abbr}#{name}</organization></contributor>"
+    end.join
+    d = docid ? "<docidentifier type='#{docid}'>x</docidentifier>" : ""
+    Nokogiri::XML("<bibitem>#{pubs}#{d}</bibitem>").root
+  end
+
+  def rank(bib, table = DEFAULT)
+    host.publisher_sort_rank(bib, table)
+  end
+
+  it "ranks by the default table, then standards, then everything else" do
+    expect(rank(bibitem({ abbrev: "ISO" }))).to eq 1
+    expect(rank(bibitem({ abbrev: "IEC" }))).to eq 2
+    expect(rank(bibitem({ abbrev: "XYZ" }, docid: "XYZ"))).to eq 3
+    expect(rank(bibitem({ abbrev: "XYZ" }))).to eq 4
+  end
+
+  it "matches abbreviations case-insensitively and by name" do
+    # abbrev arrives lowercased from AsciiDoc attribute keys
+    host.publisher_sort_config =
+      [{ abbrev: "oiml",
+         name: "International Organization of Legal Metrology", rank: 1 }]
+    expect(rank(bibitem({ abbrev: "OIML" }))).to eq 1
+    expect(rank(bibitem(
+                  { name: "International Organization of Legal Metrology" },
+                ))).to eq 1
+  end
+
+  it "lets @publisher_sort_config override the flavour default table" do
+    host.publisher_sort_config = [
+      { abbrev: "OIML", name: "x", rank: 1 },
+      { abbrev: "ISO", name: "y", rank: 2 },
+      { abbrev: "IEC", name: "z", rank: 3 },
+    ]
+    expect(rank(bibitem({ abbrev: "OIML" }))).to eq 1
+    expect(rank(bibitem({ abbrev: "ISO" }))).to eq 2
+    expect(rank(bibitem({ abbrev: "IEC" }))).to eq 3
+  end
+
+  # The secondary key must be deterministic for multiple co-publishers, so the
+  # historical JIS ordering (JIS+IEC before JIS+ISO, JIS+IEC+ISO alongside
+  # JIS+IEC) is preserved: pick the smallest co-publisher token.
+  it "picks the smallest co-publisher token as the secondary key" do
+    table = [
+      { abbrev: "JIS", name: "j", rank: 1 },
+      { abbrev: "ISO", name: "International Organization for Standardization",
+        rank: 2 },
+      { abbrev: "IEC", name: "International Electrotechnical Commission",
+        rank: 3 },
+    ]
+    second = lambda do |*pubs|
+      host.publisher_sort_second(bibitem(*pubs), table)
+    end
+    expect(second.call({ abbrev: "JIS" }, { abbrev: "IEC" })).to eq "IEC"
+    expect(second.call({ abbrev: "JIS" }, { abbrev: "ISO" })).to eq "ISO"
+    expect(second.call({ abbrev: "JIS" }, { abbrev: "IEC" },
+                       { abbrev: "ISO" })).to eq "IEC"
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-oiml/issues/12

Shared, configurable `publisher_sort_rank` / `publisher_sort_second` helpers in the base `Ref` module (base sort stays a no-op); the config is captured from `:sort-biblio-*:` attributes at converter init. Unit-spec covers tiers, case-insensitive/name matching, config override, and deterministic multi-co-publisher secondary keys.

Part of the stack-wide configurable bibliography publisher-sort feature. The bibliography's publisher sort order becomes overridable via `:sort-biblio-<abbrev>: <rank>: <name>` document attributes — set directly in a document, or injected by a metanorma-taste config. Full diagnosis, design, per-gem breakdown and verification are on the ticket.

🤖
