### PR TITLE
NamedEscapePreprocessor#log: don't let the debug write abort builds

### DIFF
--- a/lib/metanorma/converter/macros.rb
+++ b/lib/metanorma/converter/macros.rb
@@ -67,16 +67,23 @@ module Metanorma
         end.join
       end
 
-      # debugging output of results of all preprocessing,
-      # including include files concatenation and Lutaml/Liquid processing
+      # debugging output of results of all preprocessing, including include
+      # files concatenation and Lutaml/Liquid processing.
+      #
+      # Skipped for docfile-less (string/stdin) input: the target would
+      # degenerate to a single CWD-relative "./metanorma.asciidoc.log.txt" that
+      # the thousands of collection sub-compiles all truncate-rewrite (so it
+      # carries no useful diagnostics anyway). And a diagnostic write must never
+      # abort the build, so a write failure degrades to a warning rather than
+      # propagating out of the preprocessor. metanorma/metanorma-standoc#1209
       def log(doc, text)
-        source = doc.attr("docfile") || "metanorma"
+        source = doc.attr("docfile") or return
         dirname  = File.dirname(source)
         basename = File.basename(source, ".*")
         fname = File.join(dirname, "#{basename}.asciidoc.log.txt")
-        File.open(fname, "w:UTF-8") do |f|
-          f.write(text.join("\n"))
-        end
+        File.open(fname, "w:UTF-8") { |f| f.write(text.join("\n")) }
+      rescue SystemCallError => e
+        warn "metanorma: could not write preprocessing log #{fname}: #{e.message}"
       end
     end
 

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -1571,6 +1571,21 @@ RSpec.describe Metanorma::Standoc do
     expect(log).to be_equivalent_to(adoc.strip)
     FileUtils.rm_rf("spec/assets/a1.asciidoc.log.txt")
   end
+
+  # metanorma/metanorma-standoc#1209: a docfile-less (string/stdin) compile must
+  # not write a CWD-relative preprocessing log, and a diagnostic write must never
+  # raise out of the preprocessor. Thousands of collection sub-compiles would
+  # otherwise truncate-rewrite the same "./metanorma.asciidoc.log.txt", and a
+  # single failed write there aborted whole builds.
+  it "skips the preprocessing log for docfile-less input" do
+    FileUtils.rm_f("metanorma.asciidoc.log.txt")
+    preprocessor = Metanorma::Standoc::NamedEscapePreprocessor.new
+    doc = Asciidoctor::Document.new([])
+    expect { preprocessor.log(doc, %w(one two)) }.not_to raise_error
+    expect(File.exist?("metanorma.asciidoc.log.txt")).to be false
+  ensure
+    FileUtils.rm_f("metanorma.asciidoc.log.txt")
+  end
   private
 
   def mock_org_abbrevs


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-standoc/issues/1209

`NamedEscapePreprocessor#log` (`lib/metanorma/converter/macros.rb`): skip the
preprocessing debug write for docfile-less (string/stdin) input, and rescue
write failures, so a diagnostic-log write can no longer abort a collection
build. Full diagnosis and fix narrative in the ticket.

🤖
