### PR TITLE
docstage-valid attribute and draft_stage? seam for taste stage repertoires

### DIFF
--- a/lib/metanorma/cleanup/bibdata.rb
+++ b/lib/metanorma/cleanup/bibdata.rb
@@ -198,15 +198,23 @@ module Metanorma
         XML
       end
 
-      def published_base?(stage, _xmldoc)
+      def published_base?(stage, xmldoc)
         if @stage_published
           @stage_published == "true"
-        else published?(stage, _xmldoc)
+        else !draft_stage?(stage, xmldoc)
         end
       end
 
+      # Is the stage a draft (unpublished) stage? Overridable seam for
+      # flavours whose stage repertoires are not the binary
+      # published/unpublished; the :docstage-published: document
+      # attribute (@stage_published, above) trumps it either way.
+      def draft_stage?(stage, xmldoc)
+        !published?(stage, xmldoc)
+      end
+
       def published?(stage, _xmldoc)
-        stage.casecmp("published").zero?
+        stage.to_s.casecmp("published").zero?
       end
 
       # allows us to deal with doc relation localities,

--- a/lib/metanorma/converter/converter.rb
+++ b/lib/metanorma/converter/converter.rb
@@ -111,7 +111,8 @@ module Metanorma
       $xreftext = {}
 
       attr_reader :bibdb, :lang, :script, :locale, :relaton_log, :libdir, :backend,
-                  :novalid, :local_log, :output_dir, :filename, :files_to_delete
+                  :novalid, :local_log, :output_dir, :filename, :files_to_delete,
+                  :docstage_valid
 
       def initialize(backend, opts)
         doc = opts&.dig(:document)

--- a/lib/metanorma/converter/init.rb
+++ b/lib/metanorma/converter/init.rb
@@ -27,6 +27,7 @@ module Metanorma
         @document_scheme = document_scheme(node)
         @default_doctype = "standard"
         @stage_published = node.attr("docstage-published")
+        @docstage_valid = node.attr("docstage-valid")&.split(/,\s*/)
         @metadata_attrs = metadata_attrs(node)
       end
 

--- a/lib/metanorma/validate/validate.rb
+++ b/lib/metanorma/validate/validate.rb
@@ -25,7 +25,7 @@ module Metanorma
       # Instance variables to copy from converter
       def copied_instance_variables
         %i[localdir dataurimaxsize svg_conform_profile no_isobib iev_globalname
-           iev_localname c lang script locale i18n doctype]
+           iev_localname c lang script locale i18n doctype docstage_valid]
       end
 
       def initialize(converter)

--- a/spec/validate/validate_spec.rb
+++ b/spec/validate/validate_spec.rb
@@ -1983,6 +1983,27 @@ RSpec.describe Metanorma::Standoc, type: :validation do
     expect(err).not_to include("conflicting ID-types")
   end
 
+  it "parses docstage-valid into the converter and copies it to validators" do
+    input = <<~INPUT
+      = Document title
+      Author
+      :novalid:
+      :no-isobib:
+      :docstage-valid: draft, published
+    INPUT
+    conv = Metanorma::Standoc::Converter.new(:standoc, *OPTIONS)
+    conv.init(Asciidoctor.load(input, *OPTIONS))
+    expect(conv.docstage_valid).to eq %w(draft published)
+    v = Metanorma::Standoc::Validate.new(conv)
+    expect(v.instance_variable_get(:@docstage_valid))
+      .to eq %w(draft published)
+
+    conv = Metanorma::Standoc::Converter.new(:standoc, *OPTIONS)
+    conv.init(Asciidoctor.load(input.sub(/:docstage-valid:.*\n/, ""),
+                               *OPTIONS))
+    expect(conv.docstage_valid).to be_nil
+  end
+
   private
 
   def mock_plurimath_error(times)


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Part of the taste stage-repertoire takeover: tastes validate input stages against their own repertoire and advertise the mapped base stages to the flavour as `:docstage-valid:`, which supersedes the flavour's recognised-stage list. Companion PRs in metanorma-standoc, metanorma-generic, metanorma-taste, isodoc, metanorma-ieee, metanorma-nist, metanorma-iso; release metanorma-standoc first, metanorma-taste last. Full narrative on the ticket.

🤖
