### PR TITLE
Allow isodoc 3.7 (html2doc 1.12 line)

### DIFF
--- a/metanorma-standoc.gemspec
+++ b/metanorma-standoc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "asciidoctor", "~> 2.0.0"
   spec.add_dependency "crass", "~> 1.0.0"
   # spec.add_dependency "iev", "~> 0.3.5"
-  spec.add_dependency "isodoc", "~> 3.6.0"
+  spec.add_dependency "isodoc", "~> 3.6"
   spec.add_dependency "metanorma-core", "~> 0.2.0"
   spec.add_dependency "metanorma-plugin-glossarist", "~> 0.3.0"
   spec.add_dependency "metanorma-plugin-lutaml", "~> 0.7.31"


### PR DESCRIPTION
isodoc 3.7.0 is released and requires html2doc `~> 1.12` (corrected OMML math output in Word documents).

standoc's `~> 3.6.0` constraint rejects isodoc 3.7.0, which makes Gemfiles tracking isodoc main unresolvable.

This relaxes the constraint to `~> 3.6` so both the 3.6.x releases and the 3.7 line satisfy it.