### PR TITLE
Collapse whitespace around a sourcecode title with inline markup

### DIFF
--- a/lib/metanorma/converter/base.rb
+++ b/lib/metanorma/converter/base.rb
@@ -58,7 +58,7 @@ module Metanorma
             pronunciation|grammar|term|terms|termnote|termexample|source|
             origin|termref|modification)>)}x, "\\1\n")
           .gsub(%r{(<(title|name))}, "\n\\1")
-          .gsub(%r{(<sourcecode[^<>]*>)\s+(<name[^<>]*>[^<]+</name>)\s+},
+          .gsub(%r{(<sourcecode[^<>]*>)\s+(<name[^<>]*>.*?</name>)\s+}m,
                 "\\1\\2")
       end
 

--- a/spec/cleanup/blocks_spec.rb
+++ b/spec/cleanup/blocks_spec.rb
@@ -159,6 +159,23 @@ RSpec.describe Metanorma::Standoc do
       .to be_xml_equivalent_to output
   end
 
+  it "does not emit stray whitespace around a sourcecode name with inline "\
+     "markup (metanorma-pdfa#67)" do
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+
+      .Title with `A`
+      [source,xml]
+      ----
+      <P>
+      ----
+    INPUT
+    out = Asciidoctor.convert(input, *OPTIONS)
+    expect(out).to match(%r{<name[^>]*>Title with <tt>A</tt></name><body>})
+    expect(out).not_to match(%r{<sourcecode[^>]*>\s+<name})
+    expect(out).not_to match(%r{</name>\s+<body>})
+  end
+
   it "processes markup in sourcecode" do
     input = <<~INPUT
       #{ASCIIDOC_BLANK_HDR}


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/67

The standoc half of metanorma-pdfa#67: sourcecode blocks whose title contains inline monospace rendered two leading blank lines. `insert_xml_cr`'s whitespace-collapse only matched text-only sourcecode titles (`[^<]+`), so a title with inline markup (`<tt>`) kept the stray newlines standoc emits around `<name>`/`<body>`; isodoc then lexed those as leading blank lines. Widened the collapse to handle mixed-content names. Full root-cause narrative on the ticket.

## Test plan

- New regression spec in `spec/cleanup/blocks_spec.rb` (asserts tight serialisation for a mixed-content title).
- `spec/metanorma/blocks_spec.rb` + `spec/cleanup/blocks_spec.rb` green (70 examples); code indentation preserved.

🤖
