### PR TITLE
grammar compliance: bibitem element order + structured keywords

### DIFF
--- a/lib/metanorma/cleanup/bibitem.rb
+++ b/lib/metanorma/cleanup/bibitem.rb
@@ -34,6 +34,26 @@ module Metanorma
           bib.children = new.children.to_xml
         else bib << new.children.to_xml
         end
+        bibitem_reorder_elems(bib)
+      end
+
+      # canonical element order of BibliographicItem per biblio.rnc
+      BIBITEM_ELEM_ORDER =
+        %w(fetched formattedref title uri docidentifier docnumber date
+           contributor edition version note language locale script abstract
+           status copyright relation series medium place price extent size
+           accesslocation license classification keyword validity depiction)
+          .freeze
+
+      # the spans-derived fragment is appended after any elements already on
+      # the bibitem (e.g. formattedref, docnumber, date), which violates the
+      # ordered relaton content model; restore grammar order, stably
+      def bibitem_reorder_elems(bib)
+        bib.element_children
+          .sort_by
+          .with_index do |e, i|
+            [BIBITEM_ELEM_ORDER.index(e.name) || BIBITEM_ELEM_ORDER.size, i]
+          end.each { |e| bib << e }
       end
 
       def merge_bibitem_from_formattedref_span_attrs(bib, new)

--- a/lib/metanorma/cleanup/spans_to_bibitem.rb
+++ b/lib/metanorma/cleanup/spans_to_bibitem.rb
@@ -58,7 +58,9 @@ module Metanorma
             ret += span_to_docid(s, "classification")
           end
           spans[:keyword]&.each do |s|
-            ret += span_to_docid(s, "keyword")
+            # keyword content is structured per the grammar: an uncontrolled
+            # keyword is a vocab entry, not bare text
+            ret += "<keyword><vocab>#{s[:val]}</vocab></keyword>"
           end
           spans[:image]&.each do |s|
             ret += "<depiction>#{s[:val]}</depiction>"

--- a/lib/metanorma/converter/front.rb
+++ b/lib/metanorma/converter/front.rb
@@ -174,7 +174,12 @@ module Metanorma
       def metadata_keywords(node, xml)
         node.attr("keywords") or return
         node.attr("keywords").split(/,\s*/).each do |kw|
-          add_noko_elem(xml, "keyword", kw)
+          kw.empty? and next
+          # keyword content is structured per the grammar: an uncontrolled
+          # keyword is a vocab entry, not bare text
+          xml.keyword do |k|
+            add_noko_elem(k, "vocab", kw)
+          end
         end
       end
 

--- a/spec/cleanup/biblio_spec.rb
+++ b/spec/cleanup/biblio_spec.rb
@@ -1025,8 +1025,8 @@ RSpec.describe Metanorma::Standoc do
                <classification>A</classification>
                <classification type="B">C</classification>
                <classification>D</classification>
-               <keyword>key word</keyword>
-               <keyword>word key</keyword>
+               <keyword><vocab>key word</vocab></keyword>
+               <keyword><vocab>word key</vocab></keyword>
                <depiction>
                   <image src="spec/examples/rice_images/rice_image1.png" mimetype="image/png" height="auto" width="auto" filename="spec/examples/rice_images/rice_image1.png"/>
                </depiction>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -542,9 +542,9 @@ RSpec.describe Metanorma::Standoc do
            </relation>
            <classification type="a">b</classification>
            <classification type="default">c</classification>
-           <keyword>a</keyword>
-           <keyword>b</keyword>
-           <keyword>c</keyword>
+           <keyword><vocab>a</vocab></keyword>
+           <keyword><vocab>b</vocab></keyword>
+           <keyword><vocab>c</vocab></keyword>
            <ext>
              <doctype>standard</doctype>
              <flavor>standoc</flavor>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/513

Two generator fixes from the grammar-sweep census: (1) manual bibliography entries built from formattedref spans appended title/docidentifier after docnumber/date, violating the ordered relaton content model (420 hits) — bibitem children are now reordered per the biblio.rnc sequence after all merge branches; (2) `metadata_keywords` and the spans keyword path emitted bare text into the deliberately structured keyword model (354 hits) — uncontrolled keywords now wrap in `<vocab>`. Full suite green except four network-dependent isobib-cache specs (sandbox); spec expectations updated accordingly.

🤖
