### PR TITLE
Run PassFormat inline macro before Span so nested passthroughs parse

### DIFF
--- a/lib/metanorma/converter/converter.rb
+++ b/lib/metanorma/converter/converter.rb
@@ -54,6 +54,12 @@ module Metanorma
         preprocessor Metanorma::Standoc::NamedEscapePreprocessor
         inline_macro Metanorma::Standoc::PreferredTermInlineMacro
         inline_macro Metanorma::Standoc::DateInlineMacro
+        # PassFormat must run before Span (and the other bracketed inline macros
+        # below) so that a nested pass/pass-format passthrough is resolved to a
+        # bracket-free placeholder before Span delimits its own [...]; otherwise
+        # Span stops at the inner passthrough's ] and over-captures. See
+        # metanorma-standoc#1221.
+        inline_macro Metanorma::Standoc::PassFormatInlineMacro
         inline_macro Metanorma::Standoc::SpanInlineMacro
         inline_macro Metanorma::Standoc::AltTermInlineMacro
         inline_macro Metanorma::Standoc::AdmittedTermInlineMacro
@@ -79,7 +85,6 @@ module Metanorma
         inline_macro Metanorma::Standoc::FormSelectMacro
         inline_macro Metanorma::Standoc::FormOptionMacro
         inline_macro Metanorma::Standoc::ToCInlineMacro
-        inline_macro Metanorma::Standoc::PassFormatInlineMacro
         inline_macro Metanorma::Standoc::StdLinkInlineMacro
         inline_macro Metanorma::Standoc::NumberInlineMacro
         inline_macro Metanorma::Standoc::TrStyleInlineMacro

--- a/spec/metanorma/inline_spec.rb
+++ b/spec/metanorma/inline_spec.rb
@@ -1033,6 +1033,25 @@ RSpec.describe Metanorma::Standoc do
       .to be_xml_equivalent_to output
   end
 
+  it "resolves a passthrough nested inside a span without over-capturing" do
+    # metanorma-standoc#1221: PassFormat runs before Span, so the span
+    # delimits its own brackets correctly and keeps straight quotes.
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+
+      A span:pdf-operator[pass-format:straightquotes["hi"]] tail.
+    INPUT
+    output = <<~OUTPUT
+       #{BLANK_HDR}
+      <sections>
+      <p id='_'>A <span class="pdf-operator">"hi"</span> tail.</p>
+      </sections>
+      </metanorma>
+    OUTPUT
+    expect(strip_guid(Asciidoctor.convert(input, *OPTIONS)))
+      .to be_xml_equivalent_to output
+  end
+
   it "processes Metanorma XML inline pass" do
     input = <<~INPUT
       #{ASCIIDOC_BLANK_HDR}


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-standoc/issues/1221

Nesting a `pass`/`pass-format` passthrough inside a `span:type[...]` macro
broke the span's bracket boundary: span was registered before pass-format,
so it delimited its `[...]` at the inner passthrough's `]` and over-captured
the trailing text. Registering `PassFormatInlineMacro` before
`SpanInlineMacro` (and the other bracketed inline macros) lets the nested
passthrough resolve to a bracket-free placeholder first, so the span matches
cleanly. `span:pdf-operator[pass-format:straightquotes["hi"]] tail.` now →
`<span class="pdf-operator">"hi"</span> tail.` (styled span, straight quotes,
trailing text outside).

## Test plan
- New regression spec (spec/metanorma/inline_spec.rb): passthrough nested in
  a span, no over-capture, quotes straight.
- Full suite green: 528 examples, 0 failures, 1 pending (pre-existing IEV test).

🤖
